### PR TITLE
Reformat Python files using black

### DIFF
--- a/py/occampy2/compare.py
+++ b/py/occampy2/compare.py
@@ -2,6 +2,7 @@ class Compare:
     """
     WIP
     """
+
     def __init__(self):
         pass
 

--- a/py/occampy2/fit.py
+++ b/py/occampy2/fit.py
@@ -2,6 +2,7 @@ class Fit:
     """
     WIP
     """
+
     def __init__(self):
         pass
 

--- a/py/occampy2/manage_jobs.py
+++ b/py/occampy2/manage_jobs.py
@@ -2,6 +2,7 @@ class ManageJobs:
     """
     WIP
     """
+
     def __init__(self):
         pass
 

--- a/py/occampy2/search.py
+++ b/py/occampy2/search.py
@@ -2,6 +2,7 @@ class Search:
     """
     WIP
     """
+
     def __init__(self):
         pass
 

--- a/py/occampy2/show_log.py
+++ b/py/occampy2/show_log.py
@@ -2,6 +2,7 @@ class ShowLog:
     """
     WIP
     """
+
     def __init__(self):
         pass
 

--- a/py/occampy3/compare.py
+++ b/py/occampy3/compare.py
@@ -2,6 +2,7 @@ class Compare:
     """
     WIP
     """
+
     def __init__(self):
         pass
 

--- a/py/occampy3/fit.py
+++ b/py/occampy3/fit.py
@@ -2,6 +2,7 @@ class Fit:
     """
     WIP
     """
+
     def __init__(self):
         pass
 

--- a/py/occampy3/manage_jobs.py
+++ b/py/occampy3/manage_jobs.py
@@ -2,6 +2,7 @@ class ManageJobs:
     """
     WIP
     """
+
     def __init__(self):
         pass
 

--- a/py/occampy3/search.py
+++ b/py/occampy3/search.py
@@ -2,6 +2,7 @@ class Search:
     """
     WIP
     """
+
     def __init__(self):
         pass
 

--- a/py/occampy3/show_log.py
+++ b/py/occampy3/show_log.py
@@ -2,6 +2,7 @@ class ShowLog:
     """
     WIP
     """
+
     def __init__(self):
         pass
 

--- a/py/occampy3/wrappers/manager.py
+++ b/py/occampy3/wrappers/manager.py
@@ -124,4 +124,3 @@ class Manager:
     # TODO: remove and replace with the underlying functionality in the future
     def print_fit_report(self) -> None:
         self._ref.printFitReport()
-

--- a/py/occampy3/wrappers/variable_list.py
+++ b/py/occampy3/wrappers/variable_list.py
@@ -11,7 +11,7 @@ class VariableList:
         :param: ref: the reference to the VariableList object returned from the CPP engine
         """
         self._ref = ref  # type VariableList_cpp
-    
+
     def __iter__(self) -> 'VariableList':
         self._iter_index = 0
         return self

--- a/py/occampy3/wrappers/vbm_manager.py
+++ b/py/occampy3/wrappers/vbm_manager.py
@@ -37,4 +37,3 @@ class VBMManager(Manager):
 
     def set_ddf_method(self, ddf_method: int) -> None:
         self._ref.setDDFMethod(ddf_method)
-

--- a/py/py2/basic.py
+++ b/py/py2/basic.py
@@ -20,7 +20,9 @@ def main():
     # The width, levels and filter are determined here, to be used by the rest of the script below.
     if len(sys.argv) < 2:
         print 'No data file specified.'
-        print 'Usage: %s datafile [width levels] ["all"|"loopless"|"disjoint"|"chain"]' % sys.argv[0]
+        print 'Usage: %s datafile [width levels] ["all"|"loopless"|"disjoint"|"chain"]' % sys.argv[
+            0
+        ]
         sys.exit()
 
     if len(sys.argv) >= 4:
@@ -96,7 +98,9 @@ def main():
     # util.set_report_variables("Level$I, h, ddf, lr, alpha, information, pct_correct_data, aic, bic")
     # util.set_no_ipf(1)
     # For ref=bottom, use something like this:
-    util.set_report_variables("Level$I, h, ddf, lr, alpha, information, cond_pct_dh, aic, bic, incr_alpha, prog_id, pct_correct_data")
+    util.set_report_variables(
+        "Level$I, h, ddf, lr, alpha, information, cond_pct_dh, aic, bic, incr_alpha, prog_id, pct_correct_data"
+    )
     # util.set_report_variables("level$I, h, ddf, lr, alpha, information, aic, bic, incr_alpha, prog_id, ipf_iterations, ipf_error")
 
     # Perform the search or fit. Pass 1 as argument to print options, 0 not to.

--- a/py/py2/bp.py
+++ b/py/py2/bp.py
@@ -116,4 +116,3 @@ util.set_no_ipf(1)
 
 # perform the search or fit, and print report
 util.do_action(1)
-

--- a/py/py2/common.py
+++ b/py/py2/common.py
@@ -12,6 +12,6 @@ def get_unique_filename(file_name):
     dirname, filename = os.path.split(file_name)
     prefix, suffix = os.path.splitext(filename)
     prefix = '_'.join(prefix.split())
-    fd, filename = tempfile.mkstemp(suffix, prefix+"__", dirname)
+    fd, filename = tempfile.mkstemp(suffix, prefix + "__", dirname)
     os.chmod(filename, 0660)
     return filename

--- a/py/py2/distanceFunctions.py
+++ b/py/py2/distanceFunctions.py
@@ -15,10 +15,14 @@ def zipwise_fold(base, fold, proj, ls):
     for (key0, value0) in d0.items():
 
         if math.isnan(value0):
-            print "ERROR: (nan) value in fit table for file '" + ls[0]["filename"] + " with model " + ls[0]["name"]
+            print "ERROR: (nan) value in fit table for file '" + ls[0][
+                "filename"
+            ] + " with model " + ls[0]["name"]
             sys.exit(1)
         if math.isinf(value0):
-            print "ERROR: (inf) value in fit table for file '" + ls[0]["filename"] + " with model " + ls[0]["name"]
+            print "ERROR: (inf) value in fit table for file '" + ls[0][
+                "filename"
+            ] + " with model " + ls[0]["name"]
             sys.exit(1)
         if key0 in d1:
             res = fold(res, proj(value0, d1[key0]))
@@ -26,10 +30,14 @@ def zipwise_fold(base, fold, proj, ls):
             res = fold(res, proj(value0, 0.0))
     for (key1, value1) in d1.items():
         if math.isnan(value1):
-            print "ERROR: (nan) value in fit table for file '" + ls[1]["filename"] + " with model " + ls[1]["name"]
+            print "ERROR: (nan) value in fit table for file '" + ls[1][
+                "filename"
+            ] + " with model " + ls[1]["name"]
             sys.exit(1)
         if math.isinf(value1):
-            print "ERROR: (inf) value in fit table for file '" + ls[1]["filename"] + " with model " + ls[1]["name"]
+            print "ERROR: (inf) value in fit table for file '" + ls[1][
+                "filename"
+            ] + " with model " + ls[1]["name"]
             sys.exit(1)
         if key1 not in d0:
             res = fold(res, proj(0.0, value1))
@@ -80,8 +88,8 @@ distanceMetrics = {
     "Euclidean dist": euclidean_dist,
     "Hellinger dist": hellinger_dist,
     "Kullback-Leibler dist": kl_dist,
-    "Maximum dist": max_dist
-    }
+    "Maximum dist": max_dist,
+}
 
 
 def compute_distance_metric(k, compare_order):

--- a/py/py2/fit.py
+++ b/py/py2/fit.py
@@ -36,4 +36,3 @@ t3 = time.time()
 
 print "start:  %8f" % (t2 - t1)
 print "fit: %8f" % (t3 - t2)
-

--- a/py/py2/jobcontrol.py
+++ b/py/py2/jobcontrol.py
@@ -19,7 +19,7 @@ class JobControl:
                 procfd = os.popen("ps -o pid,command")
                 procstat = procfd.read()
                 procs = procstat.split('\n')
-                del(procs[0])
+                del procs[0]
                 for proc in procs:
                     if proc.find("occam") >= 0:
                         fields = re.split("[ \t]+", proc.lstrip(), 2)
@@ -29,10 +29,14 @@ class JobControl:
                             killed = True
                             break
             except Exception, inst:
-                print "<b>Exception of type ", type(inst), ": kill of ", pid, " failed.</b><p><p>"
+                print "<b>Exception of type ", type(
+                    inst
+                ), ": kill of ", pid, " failed.</b><p><p>"
                 print inst.args
             except Exception:
-                print "<b>Kill of " + pid + " failed: " + sys.exc_info()[0] + "</b><p><p>"
+                print "<b>Kill of " + pid + " failed: " + sys.exc_info()[
+                    0
+                ] + "</b><p><p>"
             if not killed:
                 print "<b>Kill of " + pid + " failed.</b><p><p>"
 
@@ -43,7 +47,7 @@ class JobControl:
         procfd = os.popen("ps -o pid,lstart,etime,pcpu,pmem,command")
         procstat = procfd.read()
         procs = procstat.split('\n')
-        del(procs[0])
+        del procs[0]
         even_row = False
         for proc in procs:
             if proc.find("occam") >= 0:
@@ -51,10 +55,21 @@ class JobControl:
                 cmds = fields[-1].split(' ')
                 if len(cmds) < 2:
                     continue
-                if "[" in cmds[0] or "defunct" in cmds[1] or "weboccam.cgi" in cmds[1] or ("weboccam.py" in cmds[1] and len(cmds) == 2):
+                if (
+                    "[" in cmds[0]
+                    or "defunct" in cmds[1]
+                    or "weboccam.cgi" in cmds[1]
+                    or ("weboccam.py" in cmds[1] and len(cmds) == 2)
+                ):
                     continue
                 del fields[-1]
-                fields[1] = " ".join(fields[1:4]) + " " + fields[5] + "<br>" + fields[4]
+                fields[1] = (
+                    " ".join(fields[1:4])
+                    + " "
+                    + fields[5]
+                    + "<br>"
+                    + fields[4]
+                )
                 del fields[2:6]
                 if even_row:
                     print "<tr valign='top'>"
@@ -71,20 +86,40 @@ class JobControl:
                     else:
                         command = cmds[0]
                 elif len(cmds) == 3:
-                    command = cmds[1] + " " + cmds[2].split('/')[-1][0:-12] + ".ctl"
+                    command = (
+                        cmds[1] + " " + cmds[2].split('/')[-1][0:-12] + ".ctl"
+                    )
                 elif len(cmds) == 4:
                     command = cmds[1] + " " + cmds[2] + "<br>" + cmds[3]
                 elif len(cmds) == 5:
                     command = cmds[1] + " " + cmds[2] + "<br>" + cmds[3]
                     if cmds[4] != "":
-                        command += '<br>\n_subject: "' + cmds[4].decode("hex") + '"'
+                        command += (
+                            '<br>\n_subject: "' + cmds[4].decode("hex") + '"'
+                        )
                 elif len(cmds) == 6:
-                    command = cmds[1].split('/')[-1] + " " + cmds[4] + "<br>" + cmds[5]
+                    command = (
+                        cmds[1].split('/')[-1]
+                        + " "
+                        + cmds[4]
+                        + "<br>"
+                        + cmds[5]
+                    )
                 elif len(cmds) == 7:
-                    command = cmds[1].split('/')[-1] + " " + cmds[4] + "<br>" + cmds[5]
+                    command = (
+                        cmds[1].split('/')[-1]
+                        + " "
+                        + cmds[4]
+                        + "<br>"
+                        + cmds[5]
+                    )
                     if cmds[6] != "":
-                        command += '<br>\n_subject: "' + cmds[6].decode("hex") + '"'
+                        command += (
+                            '<br>\n_subject: "' + cmds[6].decode("hex") + '"'
+                        )
                 print "<td>", command, "</td>"
-                print '<td><a href="weboccam.cgi?action=jobcontrol&pid=' + fields[0] + '">kill</a></td>'
+                print '<td><a href="weboccam.cgi?action=jobcontrol&pid=' + fields[
+                    0
+                ] + '">kill</a></td>'
                 print "</tr>"
         print "</table>"

--- a/py/py2/ocGraph.py
+++ b/py/py2/ocGraph.py
@@ -16,10 +16,14 @@ class StripDrawer(igraph.drawing.shapes.ShapeDrawer):
 
     @staticmethod
     def draw_path(ctx, center_x, center_y, width, height=20):
-        ctx.rectangle(center_x - width/2, center_y - height/2, width, height)
+        ctx.rectangle(
+            center_x - width / 2, center_y - height / 2, width, height
+        )
 
     @staticmethod
-    def intersection_point(center_x, center_y, source_x, source_y, width, height=20):
+    def intersection_point(
+        center_x, center_y, source_x, source_y, width, height=20
+    ):
         delta_x, delta_y = center_x - source_x, center_y - source_y
 
         if delta_x == 0 and delta_y == 0:
@@ -27,37 +31,37 @@ class StripDrawer(igraph.drawing.shapes.ShapeDrawer):
 
         if delta_y > 0 and delta_y >= delta_x >= -delta_y:
             # this is the top edge
-            ry = center_y - height/2
-            ratio = (height/2) / delta_y
-            return center_x-ratio*delta_x, ry
+            ry = center_y - height / 2
+            ratio = (height / 2) / delta_y
+            return center_x - ratio * delta_x, ry
 
         if delta_y < 0 and -delta_y >= delta_x >= delta_y:
             # this is the bottom edge
-            ry = center_y + height/2
-            ratio = (height/2) / -delta_y
-            return center_x-ratio*delta_x, ry
+            ry = center_y + height / 2
+            ratio = (height / 2) / -delta_y
+            return center_x - ratio * delta_x, ry
 
         if delta_x > 0 and delta_x >= delta_y >= -delta_x:
             # this is the left edge
-            rx = center_x - width/2
-            ratio = (width/2) / delta_x
-            return rx, center_y-ratio*delta_y
+            rx = center_x - width / 2
+            ratio = (width / 2) / delta_x
+            return rx, center_y - ratio * delta_y
 
         if delta_x < 0 and -delta_x >= delta_y >= delta_x:
             # this is the right edge
-            rx = center_x + width/2
-            ratio = (width/2) / -delta_x
-            return rx, center_y-ratio*delta_y
+            rx = center_x + width / 2
+            ratio = (width / 2) / -delta_x
+            return rx, center_y - ratio * delta_y
 
         if delta_x == 0:
             if delta_y > 0:
-                return center_x, center_y - height/2
-            return center_x, center_y + height/2
+                return center_x, center_y - height / 2
+            return center_x, center_y + height / 2
 
         if delta_y == 0:
             if delta_x > 0:
-                return center_x - width/2, center_y
-            return center_x + width/2, center_y
+                return center_x - width / 2, center_y
+            return center_x + width / 2, center_y
 
 
 igraph.drawing.shapes.ShapeDrawerDirectory.register(StripDrawer)
@@ -70,14 +74,26 @@ def textwidth(text, fontsize=14):
         return len(text) * fontsize
     surface = cairo.SVGSurface('data/undefined.svg', 600, 600)
     cr = cairo.Context(surface)
-    cr.select_font_face('sans-serif', cairo.FONT_SLANT_NORMAL, cairo.FONT_WEIGHT_BOLD)
+    cr.select_font_face(
+        'sans-serif', cairo.FONT_SLANT_NORMAL, cairo.FONT_WEIGHT_BOLD
+    )
     cr.set_font_size(fontsize)
-    x_bearing, y_bearing, width, height, x_advance, y_advance = cr.text_extents(text)
+    x_bearing, y_bearing, width, height, x_advance, y_advance = cr.text_extents(
+        text
+    )
     return width
 
 
 # Graph generation based on Teresa Schmidt's R script (2016)
-def generate(model_name, varlist, hide_iv, hide_dv, dv_name, full_var_names, all_higher_order):
+def generate(
+    model_name,
+    varlist,
+    hide_iv,
+    hide_dv,
+    dv_name,
+    full_var_names,
+    all_higher_order,
+):
 
     # TODO fix this... the split is not quite working out right.
 
@@ -151,7 +167,16 @@ def generate(model_name, varlist, hide_iv, hide_dv, dv_name, full_var_names, all
     return graph
 
 
-def print_plot(graph, layout, extension, filename, width, height, font_size, node_size_orig):
+def print_plot(
+    graph,
+    layout,
+    extension,
+    filename,
+    width,
+    height,
+    font_size,
+    node_size_orig,
+):
     # Setup the graph plotting aesthetics.
     tys = graph.vs["type"]
     tylabs = zip(graph.vs["type"], graph.vs["label"])
@@ -160,18 +185,32 @@ def print_plot(graph, layout, extension, filename, width, height, font_size, nod
     dotsize = 5
 
     # Calculate node sizes.
-    node_size = max([0 if ty else max(node_size_orig, lab_width(lab)) for (ty, lab) in tylabs])
-    size_fn = (lambda ty, lab: max(node_size, lab_width(lab))) if layout == "bipartite" else (lambda ty, lab: dotsize if ty else node_size)
+    node_size = max(
+        [
+            0 if ty else max(node_size_orig, lab_width(lab))
+            for (ty, lab) in tylabs
+        ]
+    )
+    size_fn = (
+        (lambda ty, lab: max(node_size, lab_width(lab)))
+        if layout == "bipartite"
+        else (lambda ty, lab: dotsize if ty else node_size)
+    )
 
     visual_style = {
         "vertex_size": [size_fn(ty, lab) for (ty, lab) in tylabs],
         "vertex_color": ["lightblue" if ty else "white" for ty in tys],
-        "vertex_shape": ["strip" if layout == "bipartite" and ty else "circle" for ty in tys],
-        "vertex_label_size": [0 if layout != "bipartite" and ty else fontsize for ty in tys],
-        "margin": max([size_fn(ty, lab) / 2 for (ty, lab) in tylabs] + [node_size]),
-
+        "vertex_shape": [
+            "strip" if layout == "bipartite" and ty else "circle" for ty in tys
+        ],
+        "vertex_label_size": [
+            0 if layout != "bipartite" and ty else fontsize for ty in tys
+        ],
+        "margin": max(
+            [size_fn(ty, lab) / 2 for (ty, lab) in tylabs] + [node_size]
+        ),
         "vertex_label_dist": 0,
-        "bbox": (width, height)
+        "bbox": (width, height),
     }
 
     # Set the layout. None is a valid choice.
@@ -191,7 +230,11 @@ def print_plot(graph, layout, extension, filename, width, height, font_size, nod
         elif layout == "Sugiyama":
             layout_choice = "sugiyama"
     except Exception:
-        raise RuntimeError("The hypergraph layout library failed to apply the " + layout + " layout.")
+        raise RuntimeError(
+            "The hypergraph layout library failed to apply the "
+            + layout
+            + " layout."
+        )
 
     # Generate a unique file for the graph;
     # using the layout (if any), generate a plot.
@@ -202,14 +245,18 @@ def print_plot(graph, layout, extension, filename, width, height, font_size, nod
 
 def print_svg(graph, layout, width, height, font_size, node_size):
     print "<br>"
-    graph_file = print_plot(graph, layout, "svg", "graph", width, height, font_size, node_size)
+    graph_file = print_plot(
+        graph, layout, "svg", "graph", width, height, font_size, node_size
+    )
     with open(graph_file) as gf:
         contents = gf.read()
         print contents
 
 
 def print_pdf(filename, graph, layout, width, height, font_size, node_size):
-    graph_file = print_plot(graph, layout, "pdf", filename, width, height, font_size, node_size)
+    graph_file = print_plot(
+        graph, layout, "pdf", filename, width, height, font_size, node_size
+    )
     return graph_file
 
 

--- a/py/py2/occammail.py
+++ b/py/py2/occammail.py
@@ -62,4 +62,3 @@ filename = sys.argv[2]
 email_subject = sys.argv[3].decode("hex")
 msg = build_message(sys.stdin, filename, email_subject)
 send_message(to_addr, msg)
-

--- a/py/py2/ocutils.py
+++ b/py/py2/ocutils.py
@@ -56,7 +56,9 @@ class OCUtils:
         self._percent_correct = 0
         self._ref_model = "default"
         self._report = self._manager.Report()
-        self._report.setSeparator(OCUtils.SPACE_SEP)  # align columns using spaces
+        self._report.setSeparator(
+            OCUtils.SPACE_SEP
+        )  # align columns using spaces
         self._report_file = ""
         self._report_sort_name = ""
         self._search_filter = "loopless"
@@ -105,7 +107,7 @@ class OCUtils:
     def set_report_separator(self, format_):
         occam.setHTMLMode(format_ == OCUtils.HTML_FORMAT)
         self._report.setSeparator(format_)
-        self._HTMLFormat = (format_ == OCUtils.HTML_FORMAT)
+        self._HTMLFormat = format_ == OCUtils.HTML_FORMAT
 
     def set_fit_classifier_target(self, target):
         self._fit_classifier_target = target
@@ -237,11 +239,11 @@ class OCUtils:
     # on how search is sorting the models. We want to avoid any
     # extra expensive computations
     def compute_sort_statistic(self, model):
-        if self.sort_name == "h" or self.sort_name == "information" or self.sort_name == "unexplained" or self.sort_name == "alg_t":
+        if self.sort_name in ("h", "information", "unexplained", "alg_t"):
             self._manager.computeInformationsStatistics(model)
-        elif self.sort_name == "df" or self.sort_name == "ddf":
+        elif self.sort_name in ("df", "ddf"):
             self._manager.computeDFStatistics(model)
-        elif self.sort_name == "bp_t" or self.sort_name == "bp_information" or self.sort_name == "bp_alpha":
+        elif self.sort_name in ("bp_t", "bp_information", "bp_alpha"):
             self._manager.computeBPStatistics(model)
         elif self.sort_name == "pct_correct_data":
             self._manager.computePercentCorrect(model)
@@ -268,7 +270,9 @@ class OCUtils:
                 key = new_model.get(self.sort_name)
                 if self._search_sort_dir == "descending":
                     key = -key
-                heapq.heappush(new_models_heap, ([key, new_model.get("name")], new_model))  # appending the model name makes sort alphabet-consistent
+                heapq.heappush(
+                    new_models_heap, ([key, new_model.get("name")], new_model)
+                )  # appending the model name makes sort alphabet-consistent
                 add_count += 1
             else:
                 if self._incremental_alpha:
@@ -289,10 +293,12 @@ class OCUtils:
         while len(new_models_heap) > 0:
             # make sure that we're adding unique models to the list (mostly for state-based)
             key, candidate = heapq.heappop(new_models_heap)
-            if len(
-                    best_models) < self._search_width:  # or key[0] == last_key[0]:      # comparing keys allows us to select more than <width> models,
-                if True not in [n.isEquivalentTo(candidate) for n in
-                                best_models]:  # in the case of ties
+            if (
+                len(best_models) < self._search_width
+            ):  # or key[0] == last_key[0]:      # comparing keys allows us to select more than <width> models,
+                if not any(
+                    [n.isEquivalentTo(candidate) for n in best_models]
+                ):  # in the case of ties
                     best_models.append(candidate)
             else:
                 break
@@ -302,8 +308,12 @@ class OCUtils:
         mem_used = self._manager.getMemUsage()
         if not self._hide_intermediate_output:
             print '%d new models, %ld kept; %ld total models, %ld total kept; %ld kb memory used; ' % (
-                full_count, trunc_count, self._total_gen + 1, self._total_kept + 1,
-                mem_used / 1024),
+                full_count,
+                trunc_count,
+                self._total_gen + 1,
+                self._total_kept + 1,
+                mem_used / 1024,
+            ),
         sys.stdout.flush()
         if clear_cache_flag:
             for item in new_models_heap:
@@ -383,10 +393,12 @@ class OCUtils:
         # set start model. For chain search, ignore any specific starting model
         # otherwise, if not set, set the start model based on search direction
         if (
-                self._search_filter == "chain" or self._start_model == "default") and self.search_dir == "down":
+            self._search_filter == "chain" or self._start_model == "default"
+        ) and self.search_dir == "down":
             self._start_model = "top"
         elif (
-                self._search_filter == "chain" or self._start_model == "default") and self.search_dir == "up":
+            self._search_filter == "chain" or self._start_model == "default"
+        ) and self.search_dir == "up":
             self._start_model = "bottom"
         if self._start_model == "top":
             start = self._manager.getTopRefModel()
@@ -436,11 +448,14 @@ class OCUtils:
                 print "Memory limit exceeded: stopping search"
                 break
             print i, ':',  # progress indicator
-            new_models = self.process_level(i, old_models,
-                                            i != self._search_levels)
+            new_models = self.process_level(
+                i, old_models, i != self._search_levels
+            )
             current_time = time.time()
             print '%.1f seconds, %.1f total' % (
-                current_time - last_time, current_time - start_time)
+                current_time - last_time,
+                current_time - start_time,
+            )
             sys.stdout.flush()
             last_time = current_time
             for model in new_models:
@@ -472,9 +487,13 @@ class OCUtils:
             self._start_model = "default"
         if self.search_dir == "default":
             self.search_dir = "up"
-        if (self._search_filter == "chain" or self._start_model == "default") and self.search_dir == "down":
+        if (
+            self._search_filter == "chain" or self._start_model == "default"
+        ) and self.search_dir == "down":
             self._start_model = "top"
-        elif (self._search_filter == "chain" or self._start_model == "default") and self.search_dir == "up":
+        elif (
+            self._search_filter == "chain" or self._start_model == "default"
+        ) and self.search_dir == "up":
             self._start_model = "bottom"
         if self._start_model == "top":
             start = self._manager.getTopRefModel()
@@ -517,11 +536,14 @@ class OCUtils:
                 print "Memory limit exceeded: stopping search"
                 break
             print i, ':',  # progress indicator
-            new_models = self.process_level(i, old_models,
-                                            i != self._search_levels)
+            new_models = self.process_level(
+                i, old_models, i != self._search_levels
+            )
             current_time = time.time()
             print '%.1f seconds, %.1f total' % (
-                current_time - last_time, current_time - start_time)
+                current_time - last_time,
+                current_time - start_time,
+            )
             last_time = current_time
             for model in new_models:
                 # Make sure all statistics are calculated. This won't do anything if we did it already.
@@ -568,7 +590,7 @@ class OCUtils:
 
         # in HTML mode, note that the graphs are being printed.
         if self._HTMLFormat:
-            print('<hr>')
+            print '<hr>'
 
         # Get the varlist (used for all graphs)
 
@@ -593,9 +615,12 @@ class OCUtils:
 
     def split_model(self, model_name):
         comps = model_name.split(":")
-        model = map(lambda s: [s] if (
-            s == "IV" if self.is_directed() else s == "IVI") else self.split_caps(
-            s), comps)
+        model = map(
+            lambda s: [s]
+            if (s == "IV" if self.is_directed() else s == "IVI")
+            else self.split_caps(s),
+            comps,
+        )
         return model
 
     def check_model_name(self, model_name):
@@ -636,16 +661,20 @@ class OCUtils:
                     print "<br>"
                 if saw_maybe_wrong_iv:
                     print "\n_did you mean '" + (
-                        "IV" if is_directed else "IVI") + "' instead of '" + (
-                              "IVI" if is_directed else "IV") + "'?"
+                        "IV" if is_directed else "IVI"
+                    ) + "' instead of '" + (
+                        "IVI" if is_directed else "IV"
+                    ) + "'?"
                 else:
                     print "\n Did you forget the " + (
-                        "IV" if is_directed else "IVI") + " component?"
+                        "IV" if is_directed else "IVI"
+                    ) + " component?"
                 if self._HTMLFormat:
                     print "<br>"
                 print "\n Not in model: "
                 print ", ".join(
-                    ["'" + i + "'" for i in varset.difference(modset)])
+                    ["'" + i + "'" for i in varset.difference(modset)]
+                )
                 sys.exit(1)
 
         # all variables in model are in varlist
@@ -658,8 +687,8 @@ class OCUtils:
             diffset = modset.difference(varset)
             if saw_maybe_wrong_iv or diffset == {"I", "V"}:
                 print "\n_did you mean '" + (
-                    "IV" if is_directed else "IVI") + "' instead of '" + (
-                          "IVI" if is_directed else "IV") + "'?"
+                    "IV" if is_directed else "IVI"
+                ) + "' instead of '" + ("IVI" if is_directed else "IV") + "'?"
             else:
                 print "\n Not declared: "
                 print ", ".join(["'" + i + "'" for i in diffset])
@@ -674,15 +703,16 @@ class OCUtils:
                     if self._HTMLFormat:
                         print "<br>"
                     print "\nERROR: In the model '" + model_name + "', model component '" + "".join(
-                        rel) + "' is missing the DV, '" + dv + "'."
+                        rel
+                    ) + "' is missing the DV, '" + dv + "'."
                     sys.exit(1)
 
     def print_graph(self, model_name, only):
         if only and not self._generate_gephi:
             self._generate_graph = True
         if (self._generate_graph or self._generate_gephi) and (
-                self._hide_isolated and (
-                model_name == "IVI" or model_name == "IV")):
+            self._hide_isolated and model_name in ("IV", "IVI")
+        ):
             msg = "Note: no "
             if self._generate_graph:
                 msg = msg + "hypergraph image "
@@ -693,7 +723,10 @@ class OCUtils:
 
             msg = msg + "was generated, since the model contains only "
             msg = msg + model_name
-            msg = msg + " components, which were requested to be hidden in the graph."
+            msg = (
+                "%s components, which were requested to be hidden in the graph."
+                % msg
+            )
 
             if self._HTMLFormat:
                 print "<br>"
@@ -730,13 +763,15 @@ class OCUtils:
             if self._default_fit_model != "":
                 try:
                     default_model = self._manager.makeModel(
-                        self._default_fit_model, 1)
+                        self._default_fit_model, 1
+                    )
                 except Exception:
                     print "\nERROR: Unable to create model " + self._default_fit_model
                     sys.exit(0)
                 self._report.setDefaultFitModel(default_model)
-            self._report.printConditional_DV(model, self._calc_expected_dv,
-                                             self._fit_classifier_target)
+            self._report.printConditional_DV(
+                model, self._calc_expected_dv, self._fit_classifier_target
+            )
 
             self.print_graph(model_name, only_gfx)
 
@@ -747,9 +782,14 @@ class OCUtils:
             if self._HTMLFormat:
                 if header:
                     print "Hypergraph model visualization for the Model " + model + " (using the " + self._layout_style + " layout algorithm)<br>"
-                ocGraph.print_svg(self.graphs[model], self._layout_style,
-                                  self._graph_width, self._graph_height,
-                                  self._graph_font_size, self._graph_node_size)
+                ocGraph.print_svg(
+                    self.graphs[model],
+                    self._layout_style,
+                    self._graph_width,
+                    self._graph_height,
+                    self._graph_font_size,
+                    self._graph_node_size,
+                )
                 print "<hr>"
 
     def maybe_print_graph_gephi(self, model, header):
@@ -769,21 +809,36 @@ class OCUtils:
         hide_dv = self._graph_hideDV
         full_var_names = self._full_var_names
         dv_name = ""
-        all_higher_order = (self._layout_style == "bipartite")
+        all_higher_order = self._layout_style == "bipartite"
         if self.is_directed():
             dv_name = self._report.dvName()
 
         if model in self.graphs:
             pass
         else:
-            self.graphs[model] = ocGraph.generate(model, varlist, hide_iv,
-                                                  hide_dv, dv_name,
-                                                  full_var_names,
-                                                  all_higher_order)
+            self.graphs[model] = ocGraph.generate(
+                model,
+                varlist,
+                hide_iv,
+                hide_dv,
+                dv_name,
+                full_var_names,
+                all_higher_order,
+            )
 
-    def set_gfx(self, use_gfx, layout=None, gephi=False, hide_iv=True,
-                hide_dv=True, full_var_names=False, width=640, height=480,
-                font_size=12, node_size=24):
+    def set_gfx(
+        self,
+        use_gfx,
+        layout=None,
+        gephi=False,
+        hide_iv=True,
+        hide_dv=True,
+        full_var_names=False,
+        width=640,
+        height=480,
+        font_size=12,
+        node_size=24,
+    ):
         self._generate_graph = use_gfx
         self._generate_gephi = gephi
         self._layout_style = layout
@@ -802,8 +857,9 @@ class OCUtils:
         self._report.addModel(model)
         self._manager.printFitReport(model)
         self._manager.makeFitTable(model)
-        self._report.printResiduals(model, self._skip_trained_model_table,
-                                    self._skip_ivi_tables)
+        self._report.printResiduals(
+            model, self._skip_trained_model_table, self._skip_ivi_tables
+        )
 
     def do_sb_fit(self, print_options):
         # self._manager.setValuesAreFunctions(self._values_are_functions)
@@ -817,13 +873,15 @@ class OCUtils:
             if self._default_fit_model != "":
                 try:
                     default_model = self._manager.makeSbModel(
-                        self._default_fit_model, 1)
+                        self._default_fit_model, 1
+                    )
                 except Exception:
                     print "\nERROR: Unable to create model " + self._default_fit_model
                     sys.exit(0)
                 self._report.setDefaultFitModel(default_model)
-            self._report.printConditional_DV(model, self._calc_expected_dv,
-                                             self._fit_classifier_target)
+            self._report.printConditional_DV(
+                model, self._calc_expected_dv, self._fit_classifier_target
+            )
 
             print
             print
@@ -894,7 +952,8 @@ class OCUtils:
         if self._fit_classifier_target != "":
             self.print_option(
                 "Default ('negative') state for confusion matrices",
-                self._fit_classifier_target)
+                self._fit_classifier_target,
+            )
         if r_type == 1:
             self.print_option("Starting model", self._start_model)
             self.print_option("Search direction", self.search_dir)
@@ -908,24 +967,36 @@ class OCUtils:
             self.print_option("Report preference", self._sort_dir)
 
         if r_type == 0:
-            self.print_option("Generate hypergraph images",
-                              "Y" if self._generate_graph else "N")
-            self.print_option("Generate Gephi files",
-                              "Y" if self._generate_gephi else "N")
+            self.print_option(
+                "Generate hypergraph images",
+                "Y" if self._generate_graph else "N",
+            )
+            self.print_option(
+                "Generate Gephi files", "Y" if self._generate_gephi else "N"
+            )
 
         if self._generate_graph:
-            self.print_option("Hypergraph layout style",
-                              str(self._layout_style))
+            self.print_option(
+                "Hypergraph layout style", str(self._layout_style)
+            )
             self.print_option("Hypergraph image width", str(self._graph_width))
-            self.print_option("Hypergraph image height",
-                              str(self._graph_height))
-            self.print_option("Hypergraph font size", str(self._graph_font_size))
-            self.print_option("Hypergraph node size", str(self._graph_node_size))
+            self.print_option(
+                "Hypergraph image height", str(self._graph_height)
+            )
+            self.print_option(
+                "Hypergraph font size", str(self._graph_font_size)
+            )
+            self.print_option(
+                "Hypergraph node size", str(self._graph_node_size)
+            )
 
         if self._generate_gephi or self._generate_graph:
-            self.print_option("Hide " + (
-                "IV" if self.is_directed() else "IVI") + " components in hypergraph",
-                              "Y" if self._hide_isolated else "N")
+            self.print_option(
+                "Hide "
+                + ("IV" if self.is_directed() else "IVI")
+                + " components in hypergraph",
+                "Y" if self._hide_isolated else "N",
+            )
 
         if self._HTMLFormat:
             print "</table>"
@@ -937,12 +1008,16 @@ class OCUtils:
         # Initialize a manager and the starting model
         self.set_ref_model(self._ref_model)
         self._manager.setSearchDirection(
-            1 if (self.search_dir == "down") else 0)
+            1 if (self.search_dir == "down") else 0
+        )
         self._manager.setSearchType(self.search_type())
 
         # Set up the starting model
-        start = self._manager.getTopRefModel() if (
-                self.search_dir == "down") else self._manager.getBottomRefModel()
+        start = (
+            self._manager.getTopRefModel()
+            if (self.search_dir == "down")
+            else self._manager.getBottomRefModel()
+        )
         start.level = 0
         self._manager.computeL2Statistics(start)
         self._manager.computeDependentStatistics(start)
@@ -955,8 +1030,9 @@ class OCUtils:
         old_models = [start]
         for i in xrange(1, self._search_levels + 1):
             sys.stdout.write('.')
-            new_models = self.process_level(i, old_models,
-                                            i != self._search_levels)
+            new_models = self.process_level(
+                i, old_models, i != self._search_levels
+            )
             for model in new_models:
                 self._manager.computeL2Statistics(model)
                 self._manager.computeDependentStatistics(model)
@@ -975,6 +1051,6 @@ class OCUtils:
 
     def compute_binary_statistic(self, compare_order, key):
         file_ref, model_ref, file_comp, model_comp = compare_order
-        return self._manager.computeBinaryStatistic(file_ref, model_ref,
-                                                    file_comp, model_comp,
-                                                    key)
+        return self._manager.computeBinaryStatistic(
+            file_ref, model_ref, file_comp, model_comp, key
+        )

--- a/py/py2/sbfit.py
+++ b/py/py2/sbfit.py
@@ -6,6 +6,7 @@
 # distribution of this software for license terms.
 
 import sys
+
 # sys.path.append("/www")
 import time
 

--- a/py/py2/sbsearch.py
+++ b/py/py2/sbsearch.py
@@ -7,6 +7,7 @@
 
 import resource
 import sys
+
 # sys.path.append("/www")
 import time
 
@@ -18,7 +19,9 @@ resource.setrlimit(resource.RLIMIT_CORE, [360000, 360000])
 # The width, levels and filter are determined here, to be used by the rest of the script below.
 if len(sys.argv) < 2:
     print 'No data file specified.'
-    print 'Usage: %s datafile [width levels] ["all"|"loopless"|"disjoint"|"chain"]' % sys.argv[0]
+    print 'Usage: %s datafile [width levels] ["all"|"loopless"|"disjoint"|"chain"]' % sys.argv[
+        0
+    ]
     sys.exit()
 
 if len(sys.argv) >= 4:
@@ -96,7 +99,9 @@ util.set_report_sort_name("information")
 # util.set_no_ipf(1)
 # For ref=bottom, use something like this:
 # util.set_report_variables("Level$i, h, ddf, lr, alpha, information, cond_pct_dh, aic, bic, incr_alpha, prog_id")
-util.set_report_variables("level$I, h, ddf, lr, alpha, information, aic, bic, incr_alpha, prog_id, pct_correct_data")
+util.set_report_variables(
+    "level$I, h, ddf, lr, alpha, information, aic, bic, incr_alpha, prog_id, pct_correct_data"
+)
 
 # Perform the search or fit. Pass 1 as argument to print options, 0 not to.
 t2 = time.time()

--- a/py/py2/setup.py
+++ b/py/py2/setup.py
@@ -1,10 +1,11 @@
 from distutils.core import setup
 
-setup(name='occampy',
-      version='1.0',
-      description='OCCAM Reconstructability Analysis Tools',
-      author='Tim Coutinho, Huy Yang, Lily Cox, Gabriel Miller, Sebastian Reynolds, Carla Rubio-Lamas, Evghenii Siretanu, Ian McBride',
-      author_email='NA',
-      url='https://github.com/tim-coutinho/occam',
-      packages=[],
+setup(
+    name='occampy',
+    version='1.0',
+    description='OCCAM Reconstructability Analysis Tools',
+    author='Tim Coutinho, Huy Yang, Lily Cox, Gabriel Miller, Sebastian Reynolds, Carla Rubio-Lamas, Evghenii Siretanu, Ian McBride',
+    author_email='NA',
+    url='https://github.com/tim-coutinho/occam',
+    packages=[],
 )

--- a/py/py2/weboccam.py
+++ b/py/py2/weboccam.py
@@ -7,14 +7,15 @@
 
 
 import cgi
+import cgitb
+import datetime
+import distanceFunctions
+import os
+import pickle
 import sys
 import time
-import pickle
-import zipfile
-import datetime
-import cgitb
 import traceback
-import distanceFunctions
+import zipfile
 
 from ocutils import OCUtils
 from OpagCGI import OpagCGI
@@ -47,12 +48,21 @@ def get_data_file_name(form_fields, trim=false, key='datafilename'):
     * form_fields:   the form data from the user
     * trim:         trim the extension from the filename.
     """
-    return '_'.join(apply_if(trim, lambda d: os.path.splitext(d)[0],
-                             os.path.split(form_fields[key])[1]).split())
+    return '_'.join(
+        apply_if(
+            trim,
+            lambda d: os.path.splitext(d)[0],
+            os.path.split(form_fields[key])[1],
+        ).split()
+    )
 
 
 def use_gfx(form_fields):
-    return "only_gfx" in form_fields or "gfx" in form_fields or "gephi" in form_fields
+    return (
+        "only_gfx" in form_fields
+        or "gfx" in form_fields
+        or "gephi" in form_fields
+    )
 
 
 csvname = ""
@@ -67,7 +77,8 @@ def print_headers(form_fields, text_format):
             # REDIRECT OUTPUT FOR NOW (it will be printed in output_zipfile())
             print "Content-type: application/octet-stream"
             print "Content-disposition: attachment; filename=" + get_data_file_name(
-                form_fields, true) + ".zip"
+                form_fields, true
+            ) + ".zip"
             print ""
             sys.stdout.flush()
 
@@ -114,8 +125,15 @@ def attempt_parse_int(string, default, msg, verbose):
 
     except ValueError:
         if verbose:
-            print ("WARNING: expected " + msg + " to be an integer value, but got: \"" + string + "\"; using the default value, " + str(
-                   default) + "\n")
+            print (
+                "WARNING: expected "
+                + msg
+                + " to be an integer value, but got: \""
+                + string
+                + "\"; using the default value, "
+                + str(default)
+                + "\n"
+            )
             if not text_format:
                 print "<br>"
 
@@ -123,27 +141,39 @@ def attempt_parse_int(string, default, msg, verbose):
 
 
 def graph_width():
-    return attempt_parse_int(form_fields.get("graph_width", ""), 640,
-                             "hypergraph image width",
-                             "gfx" in form_fields)
+    return attempt_parse_int(
+        form_fields.get("graph_width", ""),
+        640,
+        "hypergraph image width",
+        "gfx" in form_fields,
+    )
 
 
 def graph_height():
-    return attempt_parse_int(form_fields.get("graph_height", ""), 480,
-                             "hypergraph image height",
-                             "gfx" in form_fields)
+    return attempt_parse_int(
+        form_fields.get("graph_height", ""),
+        480,
+        "hypergraph image height",
+        "gfx" in form_fields,
+    )
 
 
 def graph_font_size():
-    return attempt_parse_int(form_fields.get("graph_font_size", ""), 12,
-                             "hypergraph font size",
-                             "gfx" in form_fields)
+    return attempt_parse_int(
+        form_fields.get("graph_font_size", ""),
+        12,
+        "hypergraph font size",
+        "gfx" in form_fields,
+    )
 
 
 def graph_node_size():
-    return attempt_parse_int(form_fields.get("graph_node_size", ""), 24,
-                             "hypergraph node size",
-                             "gfx" in form_fields)
+    return attempt_parse_int(
+        form_fields.get("graph_node_size", ""),
+        24,
+        "hypergraph node size",
+        "gfx" in form_fields,
+    )
 
 
 # Take the captured standard output,
@@ -164,11 +194,15 @@ def output_to_zip(oc):
         if "gfx" in form_fields:
             filename = modelname + ".pdf"
             print "Writing graph to " + filename
-            graph_file = ocGraph.print_pdf(modelname, graph,
-                                           form_fields["layout"],
-                                           graph_width(), graph_height(),
-                                           graph_font_size(),
-                                           graph_node_size())
+            graph_file = ocGraph.print_pdf(
+                modelname,
+                graph,
+                form_fields["layout"],
+                graph_width(),
+                graph_height(),
+                graph_font_size(),
+                graph_node_size(),
+            )
             z.write(graph_file, filename)
             sys.stdout.flush()
 
@@ -272,7 +306,8 @@ def get_data_file_alloc(form_fields, key='datafilename'):
         print "ERROR: No data file specified."
         sys.exit()
     datafile = get_unique_filename(
-        os.path.join(datadir, get_data_file_name(form_fields)))
+        os.path.join(datadir, get_data_file_name(form_fields))
+    )
     try:
         outf = open(datafile, "w", 0660)
         data = form_fields["data"]
@@ -327,7 +362,8 @@ def prepare_cached_data(form_fields):
 
     # Check that exactly 1 of datafile, refr were chosen
     if (data_file_name == "" and data_refr_name == "") or (
-            data_file_name != "" and data_refr_name != ""):
+        data_file_name != "" and data_refr_name != ""
+    ):
         print "NOTE: Exactly 1 of 'Data File' and 'Cached Data Name' must be filled out."
         sys.exit(1)
 
@@ -412,12 +448,16 @@ def unzip_data_file(datafile):
         oldfile = datafile
         zipdata = zipfile.ZipFile(datafile)
         # ignore any directories, or files in them, such as those OSX likes to make
-        ilist = [item for item in zipdata.infolist() if
-                 item.filename.find("/") == -1]
+        ilist = [
+            item
+            for item in zipdata.infolist()
+            if item.filename.find("/") == -1
+        ]
         # make sure there is only one file left
         if len(ilist) != 1:
             print "ERROR: Zip file can only contain one data file. (It appears to contain %d.)" % len(
-                ilist)
+                ilist
+            )
             sys.exit()
         # try to extract the file
         try:
@@ -494,16 +534,18 @@ def maybe_skip_ivis(form_fields, oc):
 def handle_graph_options(oc, form_fields):
     if use_gfx(form_fields):
         lo = form_fields["layout"]
-        oc.set_gfx("gfx" in form_fields,
-                   layout=lo,
-                   gephi="gephi" in form_fields,
-                   hideIV="hide_isolated" in form_fields,
-                   hideDV="hideDV" in form_fields,
-                   full_var_names="full_var_names" in form_fields,
-                   width=graph_width(),
-                   height=graph_height(),
-                   font_size=graph_font_size(),
-                   node_size=graph_node_size())
+        oc.set_gfx(
+            "gfx" in form_fields,
+            layout=lo,
+            gephi="gephi" in form_fields,
+            hideIV="hide_isolated" in form_fields,
+            hideDV="hideDV" in form_fields,
+            full_var_names="full_var_names" in form_fields,
+            width=graph_width(),
+            height=graph_height(),
+            font_size=graph_font_size(),
+            node_size=graph_node_size(),
+        )
 
 
 def action_fit(form_fields):
@@ -534,7 +576,11 @@ def action_fit(form_fields):
     # if function_flag:
     # oc.set_values_are_functions(1)
 
-    target = form_fields["negativeDVfor_confusion"] if "negativeDVfor_confusion" in form_fields else ""
+    target = (
+        form_fields["negativeDVfor_confusion"]
+        if "negativeDVfor_confusion" in form_fields
+        else ""
+    )
 
     maybe_skip_residuals(form_fields, oc)
     maybe_skip_ivis(form_fields, oc)
@@ -592,7 +638,11 @@ def action_sb_fit(form_fields):
     maybe_skip_residuals(form_fields, oc)
     maybe_skip_ivis(form_fields, oc)
 
-    target = form_fields["negativeDVfor_confusion"] if "negativeDVfor_confusion" in form_fields else ""
+    target = (
+        form_fields["negativeDVfor_confusion"]
+        if "negativeDVfor_confusion" in form_fields
+        else ""
+    )
 
     only_gfx = "only_gfx" in form_fields
     process_sb_fit(fn, form_fields["model"], target, oc, only_gfx)
@@ -681,18 +731,27 @@ def action_search(form_fields):
     reportvars += ", ddf"
     if form_fields.get("show_dlr", ""):
         reportvars += ", lr"
-    if form_fields.get("show_alpha",
-                       "") or search_sort == "alpha" or report_sort == "alpha":
+    if (
+        form_fields.get("show_alpha", "")
+        or search_sort == "alpha"
+        or report_sort == "alpha"
+    ):
         reportvars += ", alpha"
     reportvars += ", information"
     if oc.is_directed():
         if form_fields.get("show_pct_dh", ""):
             reportvars += ", cond_pct_dh"
-    if form_fields.get("show_aic",
-                       "") or search_sort == "aic" or report_sort == "aic":
+    if (
+        form_fields.get("show_aic", "")
+        or search_sort == "aic"
+        or report_sort == "aic"
+    ):
         reportvars += ", aic"
-    if form_fields.get("show_bic",
-                       "") or search_sort == "bic" or report_sort == "bic":
+    if (
+        form_fields.get("show_bic", "")
+        or search_sort == "bic"
+        or report_sort == "bic"
+    ):
         reportvars += ", bic"
 
     if form_fields.get("show_incr_a", ""):
@@ -708,8 +767,12 @@ def action_search(form_fields):
         """
 
     if oc.is_directed():
-        if form_fields.get("show_pct", "") or form_fields.get("show_pct_cover",
-                                                              "") or search_sort == "pct_correct_data" or report_sort == "pct_correct_data":
+        if (
+            form_fields.get("show_pct", "")
+            or form_fields.get("show_pct_cover", "")
+            or search_sort == "pct_correct_data"
+            or report_sort == "pct_correct_data"
+        ):
             reportvars += ", pct_correct_data"
             if form_fields.get("show_pct_cover", ""):
                 reportvars += ", pct_coverage"
@@ -734,25 +797,49 @@ def action_batch_compare(form_fields):
     # Get data from the form
 
     # Get Occam search parameters
-    search_fields = ["type", "direction", "levels", "width", "sort by",
-                     "selection function"]
+    search_fields = [
+        "type",
+        "direction",
+        "levels",
+        "width",
+        "sort by",
+        "selection function",
+    ]
     search = {key: form_fields.get(key) for key in search_fields}
 
     # Get Occam report parameters
     report_1 = []
     report_2 = []
-    report_fields_1 = ["DF(data)", "H(data)", "dBIC(model)", "dAIC(model)",
-                       "DF(model)", "H(model)"]
-    report_fields_2 = ["Absolute dist", "Information dist",
-                       "Kullback-Leibler dist", "Euclidean dist",
-                       "Maximum dist", "Hellinger dist"]
+    report_fields_1 = [
+        "DF(data)",
+        "H(data)",
+        "dBIC(model)",
+        "dAIC(model)",
+        "DF(model)",
+        "H(model)",
+    ]
+    report_fields_2 = [
+        "Absolute dist",
+        "Information dist",
+        "Kullback-Leibler dist",
+        "Euclidean dist",
+        "Maximum dist",
+        "Hellinger dist",
+    ]
 
-    d = {"max(DF)": "DF(model)", "min(H)": "H(model)",
-         "min(dAIC)": "dAIC(model)", "min(dBIC)": "dBIC(model)"}
+    d = {
+        "max(DF)": "DF(model)",
+        "min(H)": "H(model)",
+        "min(dAIC)": "dAIC(model)",
+        "min(dBIC)": "dBIC(model)",
+    }
 
     for r, rf in [(report_1, report_fields_1), (report_2, report_fields_2)]:
         for key in sorted(rf):
-            if form_fields.get(key, "") == "yes" or d[search["selection function"]] == key:
+            if (
+                form_fields.get(key, "") == "yes"
+                or d[search["selection function"]] == key
+            ):
                 r.append(key)
 
     # Check if the datafile field has a file in it.
@@ -781,20 +868,24 @@ def action_batch_compare(form_fields):
             if not (a[:-1] == b[:-1]):
                 print "ERROR: Expected matching paired data, but got<br></br>"
                 print "&emsp;&emsp;'" + sorted_data[
-                    2 * ix].filename + "',<br></br>"
+                    2 * ix
+                ].filename + "',<br></br>"
                 print "&emsp;&emsp;'" + sorted_data[
-                    2 * ix + 1].filename + "'.<br></br>"
+                    2 * ix + 1
+                ].filename + "'.<br></br>"
                 print "For each pair in the zipfile, the 2 filenames must be the same"
                 print "except for exactly 1 character immediately before the extension which differs<br></br>"
                 print "&emsp;&emsp;(e.g. 'fileA.txt', 'fileB.txt')."
                 sys.exit()
             pairs.append(
-                (a[:-1], sorted_data[2 * ix], sorted_data[2 * ix + 1]))
+                (a[:-1], sorted_data[2 * ix], sorted_data[2 * ix + 1])
+            )
         return pairs
 
     zip_data = zipfile.ZipFile(fn)
     pairs = make_pairs(
-        [i for i in zip_data.infolist() if i.filename.find("/") == -1])
+        [i for i in zip_data.infolist() if i.filename.find("/") == -1]
+    )
 
     # Define the analysis.
     # Steps:
@@ -817,8 +908,14 @@ def action_batch_compare(form_fields):
     # Figure out what statistics to include (and in what reporting order)
     def get_stat_headers():
         headers = []
-        candidate = ["H(data)", "H(model)", "DF(data)", "DF(model)",
-                     "dAIC(model)", "dBIC(model)"]
+        candidate = [
+            "H(data)",
+            "H(model)",
+            "DF(data)",
+            "DF(model)",
+            "dAIC(model)",
+            "dBIC(model)",
+        ]
         for i in report_1 + report_2:
             if i in candidate:
                 headers.append(i[:-1] + "(A))")
@@ -887,8 +984,10 @@ def action_batch_compare(form_fields):
         return d, s
 
     def compute_binary_statistics(report_items, comp_order):
-        stats = {k: distanceFunctions.compute_distance_metric(k, comp_order)
-                 for k in report_items}
+        stats = {
+            k: distanceFunctions.compute_distance_metric(k, comp_order)
+            for k in report_items
+        }
         return stats
 
     def compute_model_stats(model_a, model_b):
@@ -914,8 +1013,11 @@ def action_batch_compare(form_fields):
         model_b["filename"] = pair_name + "B.txt"
 
         best, stats_1, stats_2 = compute_model_stats(model_a, model_b)
-        return [pair_name, model_a["name"], model_b["name"],
-                best], stats_1, stats_2
+        return (
+            [pair_name, model_a["name"], model_b["name"], best],
+            stats_1,
+            stats_2,
+        )
 
     # Print out the report
     # * Print out options if requested
@@ -930,8 +1032,10 @@ def action_batch_compare(form_fields):
                 print tab_row(tab_col(k + ": ") + tab_col(v))
 
     def pp_column_list():
-        print tab_row(tab_col("columns in report: ") + tab_col(
-            ", ".join(report_1 + report_2)))
+        print tab_row(
+            tab_col("columns in report: ")
+            + tab_col(", ".join(report_1 + report_2))
+        )
 
     def pp_analysis(row):
         return "".join(map(tab_col, row))
@@ -950,8 +1054,12 @@ def action_batch_compare(form_fields):
         return s
 
     def pp_header():
-        col_headers = ["pair name", "model(A)", "model(B)",
-                       search["selection function"]] + get_stat_headers()
+        col_headers = [
+            "pair name",
+            "model(A)",
+            "model(B)",
+            search["selection function"],
+        ] + get_stat_headers()
         return "".join(map(tab_head, col_headers))
 
     # Layout the document
@@ -961,7 +1069,8 @@ def action_batch_compare(form_fields):
     if not text_format:
         print table_start
     print tab_row(
-        tab_head("Input archive: ") + tab_col(get_data_file_name(form_fields)))
+        tab_head("Input archive: ") + tab_col(get_data_file_name(form_fields))
+    )
     if print_options:
         print tab_row(tab_head("Options:"))
         pp_options()
@@ -1078,18 +1187,27 @@ def action_sb_search(form_fields):
     reportvars += ", ddf"
     if form_fields.get("show_dlr", ""):
         reportvars += ", lr"
-    if form_fields.get("show_alpha",
-                       "") or search_sort == "alpha" or report_sort == "alpha":
+    if (
+        form_fields.get("show_alpha", "")
+        or search_sort == "alpha"
+        or report_sort == "alpha"
+    ):
         reportvars += ", alpha"
     reportvars += ", information"
     if oc.is_directed():
         if form_fields.get("show_pct_dh", ""):
             reportvars += ", cond_pct_dh"
-    if form_fields.get("show_aic",
-                       "") or search_sort == "aic" or report_sort == "aic":
+    if (
+        form_fields.get("show_aic", "")
+        or search_sort == "aic"
+        or report_sort == "aic"
+    ):
         reportvars += ", aic"
-    if form_fields.get("show_bic",
-                       "") or search_sort == "bic" or report_sort == "bic":
+    if (
+        form_fields.get("show_bic", "")
+        or search_sort == "bic"
+        or report_sort == "bic"
+    ):
         reportvars += ", bic"
 
     if form_fields.get("show_incr_a", ""):
@@ -1105,8 +1223,12 @@ def action_sb_search(form_fields):
         """
 
     if oc.is_directed():
-        if form_fields.get("show_pct", "") or form_fields.get("show_pct_cover",
-                                                              "") or search_sort == "pct_correct_data" or report_sort == "pct_correct_data":
+        if (
+            form_fields.get("show_pct", "")
+            or form_fields.get("show_pct_cover", "")
+            or search_sort == "pct_correct_data"
+            or report_sort == "pct_correct_data"
+        ):
             reportvars += ", pct_correct_data"
             if form_fields.get("show_pct_cover", ""):
                 reportvars += ", pct_coverage"
@@ -1180,8 +1302,9 @@ def start_batch(form_fields):
     if get_data_file_name(form_fields) == "":
         print "ERROR: No data file specified."
         sys.exit()
-    ctlfilename = os.path.join(datadir,
-                               get_data_file_name(form_fields, true) + '.ctl')
+    ctlfilename = os.path.join(
+        datadir, get_data_file_name(form_fields, true) + '.ctl'
+    )
     ctlfilename = get_unique_filename(ctlfilename)
     csvname = get_data_file_name(form_fields, true) + '.csv'
     datafilename = get_data_file_name(form_fields)
@@ -1198,12 +1321,19 @@ def start_batch(form_fields):
     print "Process ID:", os.getpid(), "<p>"
 
     cmd = 'nohup "%s" "%s" "%s" "%s" "%s" "%s" &' % (
-        appname, sys.argv[0], ctlfilename, toaddress, csvname,
-        email_subject.encode("hex"))
+        appname,
+        sys.argv[0],
+        ctlfilename,
+        toaddress,
+        csvname,
+        email_subject.encode("hex"),
+    )
     os.system(cmd)
 
     print "<hr>Batch job started for data file '%s'.<br>Results will be sent to '%s'" % (
-        datafilename, toaddress)
+        datafilename,
+        toaddress,
+    )
 
     if len(email_subject) > 0:
         print " with email subject line including '%s'." % email_subject
@@ -1263,7 +1393,10 @@ def start_normal(form_fields):
             action_sb_fit(form_fields)
         elif form_fields["action"] == "fitbatch":
             action_fit_batch(form_fields)
-        elif form_fields["action"] == "search" or form_fields["action"] == "advanced":
+        elif (
+            form_fields["action"] == "search"
+            or form_fields["action"] == "advanced"
+        ):
             action_search(form_fields)
         elif form_fields["action"] == "log":
             action_show_log(form_fields)

--- a/py/py3/OpagCGI.py
+++ b/py/py3/OpagCGI.py
@@ -68,7 +68,7 @@ class OpagCGI:
         self.template = template
         self.template_file = None
         if not os.path.exists(self.template):
-            raise OpagMissingPrecondition("%s does not exist" % self.template)
+            raise OpagMissingPrecondition(f"{self.template} does not exist")
 
     def parse(self, dict_, header=FALSE):
         """parse(dict) -> string

--- a/py/py3/basic.py
+++ b/py/py3/basic.py
@@ -20,7 +20,9 @@ def main():
     # The width, levels and filter are determined here, to be used by the rest of the script below.
     if len(sys.argv) < 2:
         print('No data file specified.')
-        print('Usage: %s datafile [width levels] ["all"|"loopless"|"disjoint"|"chain"]' % sys.argv[0])
+        print(
+            f'Usage: {sys.argv[0]} datafile [width levels] ["all"|"loopless"|"disjoint"|"chain"]'
+        )
         sys.exit()
 
     if len(sys.argv) >= 4:
@@ -96,7 +98,9 @@ def main():
     # util.set_report_variables("Level$I, h, ddf, lr, alpha, information, pct_correct_data, aic, bic")
     # util.set_no_ipf(1)
     # For ref=bottom, use something like this:
-    util.set_report_variables("Level$I, h, ddf, lr, alpha, information, cond_pct_dh, aic, bic, incr_alpha, prog_id, pct_correct_data")
+    util.set_report_variables(
+        "Level$I, h, ddf, lr, alpha, information, cond_pct_dh, aic, bic, incr_alpha, prog_id, pct_correct_data"
+    )
     # util.set_report_variables("level$I, h, ddf, lr, alpha, information, aic, bic, incr_alpha, prog_id, ipf_iterations, ipf_error")
 
     # Perform the search or fit. Pass 1 as argument to print options, 0 not to.
@@ -104,8 +108,8 @@ def main():
     util.do_action(1)
     t3 = time.time()
 
-    print("start:  %8f" % (t2 - t1))
-    print("search: %8f" % (t3 - t2))
+    print(f"start:  {(t2 - t1):8f}")
+    print(f"search: {(t3 - t2):8f}")
 
 
 if __name__ == '__main__':

--- a/py/py3/bp.py
+++ b/py/py3/bp.py
@@ -116,4 +116,3 @@ util.set_no_ipf(1)
 
 # perform the search or fit, and print report
 util.do_action(1)
-

--- a/py/py3/common.py
+++ b/py/py3/common.py
@@ -12,6 +12,6 @@ def get_unique_filename(file_name):
     dirname, filename = os.path.split(file_name)
     prefix, suffix = os.path.splitext(filename)
     prefix = '_'.join(prefix.split())
-    fd, filename = tempfile.mkstemp(suffix, prefix + "__", dirname)
+    fd, filename = tempfile.mkstemp(suffix, f"{prefix}__", dirname)
     os.chmod(filename, 0o660)
     return filename

--- a/py/py3/common.py
+++ b/py/py3/common.py
@@ -12,6 +12,6 @@ def get_unique_filename(file_name):
     dirname, filename = os.path.split(file_name)
     prefix, suffix = os.path.splitext(filename)
     prefix = '_'.join(prefix.split())
-    fd, filename = tempfile.mkstemp(suffix, prefix+"__", dirname)
+    fd, filename = tempfile.mkstemp(suffix, prefix + "__", dirname)
     os.chmod(filename, 0o660)
     return filename

--- a/py/py3/distanceFunctions.py
+++ b/py/py3/distanceFunctions.py
@@ -15,10 +15,20 @@ def zipwise_fold(base, fold, proj, ls):
     for (key0, value0) in list(d0.items()):
 
         if math.isnan(value0):
-            print("ERROR: (nan) value in fit table for file '" + ls[0]["filename"] + " with model " + ls[0]["name"])
+            print(
+                "ERROR: (nan) value in fit table for file '"
+                + ls[0]["filename"]
+                + " with model "
+                + ls[0]["name"]
+            )
             sys.exit(1)
         if math.isinf(value0):
-            print("ERROR: (inf) value in fit table for file '" + ls[0]["filename"] + " with model " + ls[0]["name"])
+            print(
+                "ERROR: (inf) value in fit table for file '"
+                + ls[0]["filename"]
+                + " with model "
+                + ls[0]["name"]
+            )
             sys.exit(1)
         if key0 in d1:
             res = fold(res, proj(value0, d1[key0]))
@@ -26,10 +36,20 @@ def zipwise_fold(base, fold, proj, ls):
             res = fold(res, proj(value0, 0.0))
     for (key1, value1) in list(d1.items()):
         if math.isnan(value1):
-            print("ERROR: (nan) value in fit table for file '" + ls[1]["filename"] + " with model " + ls[1]["name"])
+            print(
+                "ERROR: (nan) value in fit table for file '"
+                + ls[1]["filename"]
+                + " with model "
+                + ls[1]["name"]
+            )
             sys.exit(1)
         if math.isinf(value1):
-            print("ERROR: (inf) value in fit table for file '" + ls[1]["filename"] + " with model " + ls[1]["name"])
+            print(
+                "ERROR: (inf) value in fit table for file '"
+                + ls[1]["filename"]
+                + " with model "
+                + ls[1]["name"]
+            )
             sys.exit(1)
         if key1 not in d0:
             res = fold(res, proj(0.0, value1))
@@ -80,8 +100,8 @@ distanceMetrics = {
     "Euclidean dist": euclidean_dist,
     "Hellinger dist": hellinger_dist,
     "Kullback-Leibler dist": kl_dist,
-    "Maximum dist": max_dist
-    }
+    "Maximum dist": max_dist,
+}
 
 
 def compute_distance_metric(k, compare_order):

--- a/py/py3/distanceFunctions.py
+++ b/py/py3/distanceFunctions.py
@@ -16,18 +16,12 @@ def zipwise_fold(base, fold, proj, ls):
 
         if math.isnan(value0):
             print(
-                "ERROR: (nan) value in fit table for file '"
-                + ls[0]["filename"]
-                + " with model "
-                + ls[0]["name"]
+                f"ERROR: (nan) value in fit table for file '{ls[0]['filename']}' with model {ls[0]['name']}"
             )
             sys.exit(1)
         if math.isinf(value0):
             print(
-                "ERROR: (inf) value in fit table for file '"
-                + ls[0]["filename"]
-                + " with model "
-                + ls[0]["name"]
+                f"ERROR: (inf) value in fit table for file '{ls[0]['filename']}' with model {ls[0]['name']}"
             )
             sys.exit(1)
         if key0 in d1:
@@ -37,18 +31,12 @@ def zipwise_fold(base, fold, proj, ls):
     for (key1, value1) in list(d1.items()):
         if math.isnan(value1):
             print(
-                "ERROR: (nan) value in fit table for file '"
-                + ls[1]["filename"]
-                + " with model "
-                + ls[1]["name"]
+                f"ERROR: (nan) value in fit table for file '{ls[1]['filename']}' with model {ls[1]['name']}"
             )
             sys.exit(1)
         if math.isinf(value1):
             print(
-                "ERROR: (inf) value in fit table for file '"
-                + ls[1]["filename"]
-                + " with model "
-                + ls[1]["name"]
+                f"ERROR: (inf) value in fit table for file '{ls[1]['filename']}' with model {ls[1]['name']}"
             )
             sys.exit(1)
         if key1 not in d0:

--- a/py/py3/fit.py
+++ b/py/py3/fit.py
@@ -14,7 +14,7 @@ from ocutils import OCUtils
 
 if len(sys.argv) < 3:
     print('Incorrect parameters.')
-    print('Usage: %s datafile model' % sys.argv[0])
+    print(f'Usage: {sys.argv[0]} datafile model')
     sys.exit()
 
 
@@ -34,6 +34,5 @@ t2 = time.time()
 oc.do_action(1)
 t3 = time.time()
 
-print("start:  %8f" % (t2 - t1))
-print("fit: %8f" % (t3 - t2))
-
+print(f"start:  {(t2 - t1):8f}")
+print(f"fit: {(t3 - t2):8f}")

--- a/py/py3/fit.py
+++ b/py/py3/fit.py
@@ -13,8 +13,7 @@ from ocutils import OCUtils
 # sys.path.append("/www")
 
 if len(sys.argv) < 3:
-    print('Incorrect parameters.')
-    print(f'Usage: {sys.argv[0]} datafile model')
+    print(f'Incorrect parameters.\nUsage: {sys.argv[0]} datafile model')
     sys.exit()
 
 

--- a/py/py3/jobcontrol.py
+++ b/py/py3/jobcontrol.py
@@ -25,28 +25,20 @@ class JobControl:
                         fields = re.split("[ \t]+", proc.lstrip(), 2)
                         if fields[0] != "" and int(fields[0]) == int(pid):
                             os.kill(int(pid), 9)
-                            print("<b>Job " + pid + " killed.</b><p>")
+                            print(f"<b>Job {pid} killed.</b><p>")
                             killed = True
                             break
             except Exception as inst:
                 print(
-                    "<b>Exception of type ",
-                    type(inst),
-                    ": kill of ",
-                    pid,
-                    " failed.</b><p><p>",
+                    f"<b>Exception of type {type(inst)}: kill of {pid} failed.</b><p><p>"
                 )
                 print(inst.args)
             except Exception:
                 print(
-                    "<b>Kill of "
-                    + pid
-                    + " failed: "
-                    + sys.exc_info()[0]
-                    + "</b><p><p>"
+                    f"<b>Kill of {pid} failed: {sys.exc_info()[0]}</b><p><p>"
                 )
             if not killed:
-                print("<b>Kill of " + pid + " failed.</b><p><p>")
+                print(f"<b>Kill of {pid} failed.</b><p><p>")
 
         # Show active occam-related jobs
         print("<b>Active Jobs</b><p>")
@@ -73,13 +65,9 @@ class JobControl:
                 ):
                     continue
                 fields.pop()
-                fields[1] = (
-                    " ".join(fields[1:4])
-                    + " "
-                    + fields[5]
-                    + "<br>"
-                    + fields[4]
-                )
+                fields[
+                    1
+                ] = f"{' '.join(fields[1:4])} {fields[5]}<br>{fields[4]}"
                 del fields[2:6]
                 if even_row:
                     print("<tr valign='top'>")
@@ -88,7 +76,7 @@ class JobControl:
                     print("<tr class=r1 valign='top'>")
                     even_row = True
                 for n in range(0, len(fields)):
-                    print("<td>", fields[n], "</td>")
+                    print(f"<td>{fields[n]}</td>")
                 command = ""
                 if len(cmds) == 2:
                     if cmds[1] != "":
@@ -96,42 +84,26 @@ class JobControl:
                     else:
                         command = cmds[0]
                 elif len(cmds) == 3:
-                    command = (
-                        cmds[1] + " " + cmds[2].split('/')[-1][0:-12] + ".ctl"
-                    )
+                    command = f"{cmds[1]} {cmds[2].split('/')[-1][0:-12]}.ctl"
                 elif len(cmds) == 4:
-                    command = cmds[1] + " " + cmds[2] + "<br>" + cmds[3]
+                    command = f"{cmds[1]} {cmds[2]}<br>{cmds[3]}"
                 elif len(cmds) == 5:
-                    command = cmds[1] + " " + cmds[2] + "<br>" + cmds[3]
+                    command = f"{cmds[1]} {cmds[2]}<br>{cmds[3]}"
                     if cmds[4] != "":
-                        command += (
-                            '<br>\n_subject: "' + cmds[4].decode("hex") + '"'
-                        )
+                        command += f'<br>\n_subject: "{cmds[4].decode("hex")}"'
                 elif len(cmds) == 6:
                     command = (
-                        cmds[1].split('/')[-1]
-                        + " "
-                        + cmds[4]
-                        + "<br>"
-                        + cmds[5]
+                        f"{cmds[1].split('/')[-1]} {cmds[4]}<br>{cmds[5]}"
                     )
                 elif len(cmds) == 7:
                     command = (
-                        cmds[1].split('/')[-1]
-                        + " "
-                        + cmds[4]
-                        + "<br>"
-                        + cmds[5]
+                        f"{cmds[1].split('/')[-1]} {cmds[4]}<br>{cmds[5]}"
                     )
                     if cmds[6] != "":
-                        command += (
-                            '<br>\n_subject: "' + cmds[6].decode("hex") + '"'
-                        )
-                print("<td>", command, "</td>")
+                        command += f'<br>\n_subject: "{cmds[6].decode("hex")}"'
+                print(f"<td>{command}</td>")
                 print(
-                    '<td><a href="weboccam.cgi?action=jobcontrol&pid='
-                    + fields[0]
-                    + '">kill</a></td>'
+                    f'<td><a href="weboccam.cgi?action=jobcontrol&pid={fields[0]}">kill</a></td>'
                 )
                 print("</tr>")
         print("</table>")

--- a/py/py3/jobcontrol.py
+++ b/py/py3/jobcontrol.py
@@ -19,7 +19,7 @@ class JobControl:
                 procfd = os.popen("ps -o pid,command")
                 procstat = procfd.read()
                 procs = procstat.split('\n')
-                del(procs[0])
+                procs.pop(0)
                 for proc in procs:
                     if proc.find("occam") >= 0:
                         fields = re.split("[ \t]+", proc.lstrip(), 2)
@@ -29,21 +29,35 @@ class JobControl:
                             killed = True
                             break
             except Exception as inst:
-                print("<b>Exception of type ", type(inst), ": kill of ", pid, " failed.</b><p><p>")
+                print(
+                    "<b>Exception of type ",
+                    type(inst),
+                    ": kill of ",
+                    pid,
+                    " failed.</b><p><p>",
+                )
                 print(inst.args)
             except Exception:
-                print("<b>Kill of " + pid + " failed: " + sys.exc_info()[0] + "</b><p><p>")
+                print(
+                    "<b>Kill of "
+                    + pid
+                    + " failed: "
+                    + sys.exc_info()[0]
+                    + "</b><p><p>"
+                )
             if not killed:
                 print("<b>Kill of " + pid + " failed.</b><p><p>")
 
         # Show active occam-related jobs
         print("<b>Active Jobs</b><p>")
         print("<table class='data' width='100%'>")
-        print("<tr class=em align=left><th>Process</th><th>Start Time</th><th>Elapsed Time</th><td>%CPU</th><th>%Mem</th><th width='40%'>Command</th><th> </th></tr>")
+        print(
+            "<tr class=em align=left><th>Process</th><th>Start Time</th><th>Elapsed Time</th><td>%CPU</th><th>%Mem</th><th width='40%'>Command</th><th> </th></tr>"
+        )
         procfd = os.popen("ps -o pid,lstart,etime,pcpu,pmem,command")
         procstat = procfd.read()
         procs = procstat.split('\n')
-        del(procs[0])
+        procs.pop(0)
         even_row = False
         for proc in procs:
             if proc.find("occam") >= 0:
@@ -51,10 +65,21 @@ class JobControl:
                 cmds = fields[-1].split(' ')
                 if len(cmds) < 2:
                     continue
-                if "[" in cmds[0] or "defunct" in cmds[1] or "weboccam.cgi" in cmds[1] or ("weboccam.py" in cmds[1] and len(cmds) == 2):
+                if (
+                    "[" in cmds[0]
+                    or "defunct" in cmds[1]
+                    or "weboccam.cgi" in cmds[1]
+                    or ("weboccam.py" in cmds[1] and len(cmds) == 2)
+                ):
                     continue
-                del fields[-1]
-                fields[1] = " ".join(fields[1:4]) + " " + fields[5] + "<br>" + fields[4]
+                fields.pop()
+                fields[1] = (
+                    " ".join(fields[1:4])
+                    + " "
+                    + fields[5]
+                    + "<br>"
+                    + fields[4]
+                )
                 del fields[2:6]
                 if even_row:
                     print("<tr valign='top'>")
@@ -71,20 +96,42 @@ class JobControl:
                     else:
                         command = cmds[0]
                 elif len(cmds) == 3:
-                    command = cmds[1] + " " + cmds[2].split('/')[-1][0:-12] + ".ctl"
+                    command = (
+                        cmds[1] + " " + cmds[2].split('/')[-1][0:-12] + ".ctl"
+                    )
                 elif len(cmds) == 4:
                     command = cmds[1] + " " + cmds[2] + "<br>" + cmds[3]
                 elif len(cmds) == 5:
                     command = cmds[1] + " " + cmds[2] + "<br>" + cmds[3]
                     if cmds[4] != "":
-                        command += '<br>\n_subject: "' + cmds[4].decode("hex") + '"'
+                        command += (
+                            '<br>\n_subject: "' + cmds[4].decode("hex") + '"'
+                        )
                 elif len(cmds) == 6:
-                    command = cmds[1].split('/')[-1] + " " + cmds[4] + "<br>" + cmds[5]
+                    command = (
+                        cmds[1].split('/')[-1]
+                        + " "
+                        + cmds[4]
+                        + "<br>"
+                        + cmds[5]
+                    )
                 elif len(cmds) == 7:
-                    command = cmds[1].split('/')[-1] + " " + cmds[4] + "<br>" + cmds[5]
+                    command = (
+                        cmds[1].split('/')[-1]
+                        + " "
+                        + cmds[4]
+                        + "<br>"
+                        + cmds[5]
+                    )
                     if cmds[6] != "":
-                        command += '<br>\n_subject: "' + cmds[6].decode("hex") + '"'
+                        command += (
+                            '<br>\n_subject: "' + cmds[6].decode("hex") + '"'
+                        )
                 print("<td>", command, "</td>")
-                print('<td><a href="weboccam.cgi?action=jobcontrol&pid=' + fields[0] + '">kill</a></td>')
+                print(
+                    '<td><a href="weboccam.cgi?action=jobcontrol&pid='
+                    + fields[0]
+                    + '">kill</a></td>'
+                )
                 print("</tr>")
         print("</table>")

--- a/py/py3/ocGraph.py
+++ b/py/py3/ocGraph.py
@@ -231,14 +231,12 @@ def print_plot(
             layout_choice = "sugiyama"
     except Exception:
         raise RuntimeError(
-            "The hypergraph layout library failed to apply the "
-            + layout
-            + " layout."
+            f"The hypergraph layout library failed to apply the {layout} layout."
         )
 
     # Generate a unique file for the graph;
     # using the layout (if any), generate a plot.
-    graph_file = get_unique_filename("data/" + filename + "." + extension)
+    graph_file = get_unique_filename(f"data/{filename}.{extension}")
     igraph.plot(graph, graph_file, layout=layout_choice, **visual_style)
     return graph_file
 
@@ -281,7 +279,7 @@ def gephi_nodes(graph):
         ty = "Hyper_edge" if n["type"] else "Variable"
         size = 4 if n["type"] else 10
         line = ",".join([n["abbrev"], n["name"], ty, str(size)])
-        content += line + "\n"
+        content += f"{line}\n"
     return header + content
 
 
@@ -291,6 +289,6 @@ def gephi_edges(graph):
     for n1, n2 in graph.get_edgelist():
         nn1 = graph.vs[n1]
         nn2 = graph.vs[n2]
-        content += nn1["abbrev"] + "," + nn2["abbrev"] + "\n"
+        content += f"{nn1['abbrev']},{nn2['abbrev']}\n"
 
     return header + content

--- a/py/py3/ocGraph.py
+++ b/py/py3/ocGraph.py
@@ -16,10 +16,14 @@ class StripDrawer(igraph.drawing.shapes.ShapeDrawer):
 
     @staticmethod
     def draw_path(ctx, center_x, center_y, width, height=20):
-        ctx.rectangle(center_x - width/2, center_y - height/2, width, height)
+        ctx.rectangle(
+            center_x - width / 2, center_y - height / 2, width, height
+        )
 
     @staticmethod
-    def intersection_point(center_x, center_y, source_x, source_y, width, height=20):
+    def intersection_point(
+        center_x, center_y, source_x, source_y, width, height=20
+    ):
         delta_x, delta_y = center_x - source_x, center_y - source_y
 
         if delta_x == 0 and delta_y == 0:
@@ -27,37 +31,37 @@ class StripDrawer(igraph.drawing.shapes.ShapeDrawer):
 
         if delta_y > 0 and delta_y >= delta_x >= -delta_y:
             # this is the top edge
-            ry = center_y - height/2
-            ratio = (height/2) / delta_y
-            return center_x-ratio*delta_x, ry
+            ry = center_y - height / 2
+            ratio = (height / 2) / delta_y
+            return center_x - ratio * delta_x, ry
 
         if delta_y < 0 and -delta_y >= delta_x >= delta_y:
             # this is the bottom edge
-            ry = center_y + height/2
-            ratio = (height/2) / -delta_y
-            return center_x-ratio*delta_x, ry
+            ry = center_y + height / 2
+            ratio = (height / 2) / -delta_y
+            return center_x - ratio * delta_x, ry
 
         if delta_x > 0 and delta_x >= delta_y >= -delta_x:
             # this is the left edge
-            rx = center_x - width/2
-            ratio = (width/2) / delta_x
-            return rx, center_y-ratio*delta_y
+            rx = center_x - width / 2
+            ratio = (width / 2) / delta_x
+            return rx, center_y - ratio * delta_y
 
         if delta_x < 0 and -delta_x >= delta_y >= delta_x:
             # this is the right edge
-            rx = center_x + width/2
-            ratio = (width/2) / -delta_x
-            return rx, center_y-ratio*delta_y
+            rx = center_x + width / 2
+            ratio = (width / 2) / -delta_x
+            return rx, center_y - ratio * delta_y
 
         if delta_x == 0:
             if delta_y > 0:
-                return center_x, center_y - height/2
-            return center_x, center_y + height/2
+                return center_x, center_y - height / 2
+            return center_x, center_y + height / 2
 
         if delta_y == 0:
             if delta_x > 0:
-                return center_x - width/2, center_y
-            return center_x + width/2, center_y
+                return center_x - width / 2, center_y
+            return center_x + width / 2, center_y
 
 
 igraph.drawing.shapes.ShapeDrawerDirectory.register(StripDrawer)
@@ -70,14 +74,26 @@ def textwidth(text, fontsize=14):
         return len(text) * fontsize
     surface = cairo.SVGSurface('data/undefined.svg', 600, 600)
     cr = cairo.Context(surface)
-    cr.select_font_face('sans-serif', cairo.FONT_SLANT_NORMAL, cairo.FONT_WEIGHT_BOLD)
+    cr.select_font_face(
+        'sans-serif', cairo.FONT_SLANT_NORMAL, cairo.FONT_WEIGHT_BOLD
+    )
     cr.set_font_size(fontsize)
-    x_bearing, y_bearing, width, height, x_advance, y_advance = cr.text_extents(text)
+    x_bearing, y_bearing, width, height, x_advance, y_advance = cr.text_extents(
+        text
+    )
     return width
 
 
 # Graph generation based on Teresa Schmidt's R script (2016)
-def generate(model_name, varlist, hide_iv, hide_dv, dv_name, full_var_names, all_higher_order):
+def generate(
+    model_name,
+    varlist,
+    hide_iv,
+    hide_dv,
+    dv_name,
+    full_var_names,
+    all_higher_order,
+):
 
     # TODO fix this... the split is not quite working out right.
 
@@ -151,7 +167,16 @@ def generate(model_name, varlist, hide_iv, hide_dv, dv_name, full_var_names, all
     return graph
 
 
-def print_plot(graph, layout, extension, filename, width, height, font_size, node_size_orig):
+def print_plot(
+    graph,
+    layout,
+    extension,
+    filename,
+    width,
+    height,
+    font_size,
+    node_size_orig,
+):
     # Setup the graph plotting aesthetics.
     tys = graph.vs["type"]
     tylabs = list(zip(graph.vs["type"], graph.vs["label"]))
@@ -160,18 +185,32 @@ def print_plot(graph, layout, extension, filename, width, height, font_size, nod
     dotsize = 5
 
     # Calculate node sizes.
-    node_size = max([0 if ty else max(node_size_orig, lab_width(lab)) for (ty, lab) in tylabs])
-    size_fn = (lambda ty, lab: max(node_size, lab_width(lab))) if layout == "bipartite" else (lambda ty, lab: dotsize if ty else node_size)
+    node_size = max(
+        [
+            0 if ty else max(node_size_orig, lab_width(lab))
+            for (ty, lab) in tylabs
+        ]
+    )
+    size_fn = (
+        (lambda ty, lab: max(node_size, lab_width(lab)))
+        if layout == "bipartite"
+        else (lambda ty, lab: dotsize if ty else node_size)
+    )
 
     visual_style = {
         "vertex_size": [size_fn(ty, lab) for (ty, lab) in tylabs],
         "vertex_color": ["lightblue" if ty else "white" for ty in tys],
-        "vertex_shape": ["strip" if layout == "bipartite" and ty else "circle" for ty in tys],
-        "vertex_label_size": [0 if layout != "bipartite" and ty else fontsize for ty in tys],
-        "margin": max([size_fn(ty, lab) / 2 for (ty, lab) in tylabs] + [node_size]),
-
+        "vertex_shape": [
+            "strip" if layout == "bipartite" and ty else "circle" for ty in tys
+        ],
+        "vertex_label_size": [
+            0 if layout != "bipartite" and ty else fontsize for ty in tys
+        ],
+        "margin": max(
+            [size_fn(ty, lab) / 2 for (ty, lab) in tylabs] + [node_size]
+        ),
         "vertex_label_dist": 0,
-        "bbox": (width, height)
+        "bbox": (width, height),
     }
 
     # Set the layout. None is a valid choice.
@@ -191,7 +230,11 @@ def print_plot(graph, layout, extension, filename, width, height, font_size, nod
         elif layout == "Sugiyama":
             layout_choice = "sugiyama"
     except Exception:
-        raise RuntimeError("The hypergraph layout library failed to apply the " + layout + " layout.")
+        raise RuntimeError(
+            "The hypergraph layout library failed to apply the "
+            + layout
+            + " layout."
+        )
 
     # Generate a unique file for the graph;
     # using the layout (if any), generate a plot.
@@ -202,14 +245,18 @@ def print_plot(graph, layout, extension, filename, width, height, font_size, nod
 
 def print_svg(graph, layout, width, height, font_size, node_size):
     print("<br>")
-    graph_file = print_plot(graph, layout, "svg", "graph", width, height, font_size, node_size)
+    graph_file = print_plot(
+        graph, layout, "svg", "graph", width, height, font_size, node_size
+    )
     with open(graph_file) as gf:
         contents = gf.read()
         print(contents)
 
 
 def print_pdf(filename, graph, layout, width, height, font_size, node_size):
-    graph_file = print_plot(graph, layout, "pdf", filename, width, height, font_size, node_size)
+    graph_file = print_plot(
+        graph, layout, "pdf", filename, width, height, font_size, node_size
+    )
     return graph_file
 
 

--- a/py/py3/occammail.py
+++ b/py/py3/occammail.py
@@ -62,4 +62,3 @@ filename = sys.argv[2]
 email_subject = sys.argv[3].decode("hex")
 msg = build_message(sys.stdin, filename, email_subject)
 send_message(to_addr, msg)
-

--- a/py/py3/ocutils.py
+++ b/py/py3/ocutils.py
@@ -698,7 +698,7 @@ class OCUtils:
             diffset = modset.difference(varset)
             if saw_maybe_wrong_iv or diffset == {"I", "V"}:
                 print(
-                    f"\n_did you mean '{"IV" if is_directed else "IVI"}' instead of '{"IVI" if is_directed else "IV"}'?"
+                    f"\n_did you mean '{'IV' if is_directed else 'IVI'}' instead of '{'IVI' if is_directed else 'IV'}'?"
                 )
             else:
                 print("\n Not declared: ")

--- a/py/py3/ocutils.py
+++ b/py/py3/ocutils.py
@@ -7,7 +7,7 @@
 # coding=utf8
 import heapq
 import ocGraph
-import occam3
+import occam
 import re
 import sys
 import time
@@ -26,9 +26,9 @@ class OCUtils:
 
     def __init__(self, man="VB"):
         if man == "VB":
-            self._manager = occam3.VBMManager()
+            self._manager = occam.VBMManager()
         else:
-            self._manager = occam3.SBMManager()
+            self._manager = occam.SBMManager()
         self._action = ""
         self._alpha_threshold = 0.05
         self._bp_statistics = 0
@@ -105,7 +105,7 @@ class OCUtils:
             self._incremental_alpha = 1
 
     def set_report_separator(self, format_):
-        occam3.setHTMLMode(format_ == OCUtils.HTML_FORMAT)
+        occam.setHTMLMode(format_ == OCUtils.HTML_FORMAT)
         self._report.setSeparator(format_)
         self._HTMLFormat = format_ == OCUtils.HTML_FORMAT
 
@@ -317,8 +317,11 @@ class OCUtils:
         mem_used = self._manager.getMemUsage()
         if not self._hide_intermediate_output:
             print(
-                f'{full_count} new models, {trunc_count} kept; {self._total_gen + 1} total models, {self._total_kept + 1} total kept; {mem_used / 1024} kb memory used; ',
-                end=' ',
+                f'{full_count} new models, {trunc_count} kept; '
+                '{self._total_gen + 1} total models, '
+                '{self._total_kept + 1} total kept; '
+                '{mem_used / 1024} kb memory used; ',
+                end=' '
             )
         sys.stdout.flush()
         if clear_cache_flag:
@@ -444,7 +447,7 @@ class OCUtils:
         try:
             self._manager.setSearchType(self.search_type())
         except Exception:
-            print("ERROR: UNDEFINED SEARCH TYPE " + self.search_type())
+            print(f"ERROR: UNDEFINED SEARCH TYPE {self.search_type()}")
             return
         # process each level, up to the number of levels indicated. Each of the best models
         # is added to the report generator for later output
@@ -489,7 +492,7 @@ class OCUtils:
         if self._HTMLFormat:
             print('</pre><br>')
         else:
-            print("")
+            print()
 
     def do_sb_search(self, print_options):
         if self._start_model == "":
@@ -533,7 +536,7 @@ class OCUtils:
         try:
             self._manager.setSearchType(self.sb_search_type())
         except Exception:
-            print("ERROR: UNDEFINED SEARCH TYPE " + self.sb_search_type())
+            print(f"ERROR: UNDEFINED SEARCH TYPE {self.sb_search_type()}")
             return
         if self._HTMLFormat:
             print('<pre>')
@@ -575,7 +578,7 @@ class OCUtils:
         if self._HTMLFormat:
             print('</pre><br>')
         else:
-            print("")
+            print()
 
     def print_search_report(self):
         # sort the report as requested, and print it.
@@ -665,34 +668,22 @@ class OCUtils:
                 if self._HTMLFormat:
                     print("<br>")
                 print(
-                    "\nERROR: Not all declared variables are present in the model, '"
-                    + model_name
-                    + "'."
+                    f"\nERROR: Not all declared variables are present in the model, '{model_name}'."
                 )
                 if self._HTMLFormat:
                     print("<br>")
                 if saw_maybe_wrong_iv:
                     print(
-                        "\n_did you mean '"
-                        + ("IV" if is_directed else "IVI")
-                        + "' instead of '"
-                        + ("IVI" if is_directed else "IV")
-                        + "'?"
+                        f"\n_did you mean '{'IV' if is_directed else 'IVI'}' instead of '{'IVI' if is_directed else 'IV'}"
                     )
                 else:
                     print(
-                        "\n Did you forget the "
-                        + ("IV" if is_directed else "IVI")
-                        + " component?"
+                        f"\n Did you forget the {'IV' if is_directed else 'IVI'} component?"
                     )
                 if self._HTMLFormat:
                     print("<br>")
                 print("\n Not in model: ")
-                print(
-                    ", ".join(
-                        ["'" + i + "'" for i in varset.difference(modset)]
-                    )
-                )
+                print(", ".join([f"'{i}'" for i in varset.difference(modset)]))
                 sys.exit(1)
 
         # all variables in model are in varlist
@@ -700,24 +691,18 @@ class OCUtils:
             if self._HTMLFormat:
                 print("<br>")
             print(
-                "\nERROR: Not all variables in the model '"
-                + model_name
-                + "' are declared in the variable list."
+                f"\nERROR: Not all variables in the model '{model_name}' are declared in the variable list."
             )
             if self._HTMLFormat:
                 print("<br>")
             diffset = modset.difference(varset)
             if saw_maybe_wrong_iv or diffset == {"I", "V"}:
                 print(
-                    "\n_did you mean '"
-                    + ("IV" if is_directed else "IVI")
-                    + "' instead of '"
-                    + ("IVI" if is_directed else "IV")
-                    + "'?"
+                    f"\n_did you mean '{"IV" if is_directed else "IVI"}' instead of '{"IVI" if is_directed else "IV"}'?"
                 )
             else:
                 print("\n Not declared: ")
-                print(", ".join(["'" + i + "'" for i in diffset]))
+                print(", ".join([f"'{i}'" for i in diffset]))
 
             sys.exit(1)
 
@@ -729,13 +714,7 @@ class OCUtils:
                     if self._HTMLFormat:
                         print("<br>")
                     print(
-                        "\nERROR: In the model '"
-                        + model_name
-                        + "', model component '"
-                        + "".join(rel)
-                        + "' is missing the DV, '"
-                        + dv
-                        + "'."
+                        f"\nERROR: In the model '{model_name}', model component '{''.join(rel)}' is missing the DV, '{dv}'."
                     )
                     sys.exit(1)
 
@@ -747,18 +726,14 @@ class OCUtils:
         ):
             msg = "Note: no "
             if self._generate_graph:
-                msg = msg + "hypergraph image "
+                msg += "hypergraph image "
             if self._generate_graph and self._generate_gephi:
-                msg = msg + "or "
+                msg += "or "
             if self._generate_gephi:
-                msg = msg + "Gephi input "
-
-            msg = msg + "was generated, since the model contains only "
-            msg = msg + model_name
-            msg = (
-                msg
-                + " components, which were requested to be hidden in the graph."
-            )
+                msg += "Gephi input "
+            msg += (" was generated, since the model contains only "
+                    f"{model_name} components, which were requested to be "
+                    "hidden in the graph")
 
             if self._HTMLFormat:
                 print("<br>")
@@ -769,8 +744,7 @@ class OCUtils:
         else:
             self.maybe_print_graph_svg(model_name, True)
             self.maybe_print_graph_gephi(model_name, True)
-        print()
-        print()
+        print("\n")
 
     def do_fit(self, print_options, only_gfx):
         # self._manager.setValuesAreFunctions(self._values_are_functions)
@@ -798,10 +772,7 @@ class OCUtils:
                         self._default_fit_model, 1
                     )
                 except Exception:
-                    print(
-                        "\nERROR: Unable to create model "
-                        + self._default_fit_model
-                    )
+                    print(f"\nERROR: Unable to create model {self._default_fit_model}")
                     sys.exit(0)
                 self._report.setDefaultFitModel(default_model)
             self._report.printConditional_DV(
@@ -817,11 +788,7 @@ class OCUtils:
             if self._HTMLFormat:
                 if header:
                     print(
-                        "Hypergraph model visualization for the Model "
-                        + model
-                        + " (using the "
-                        + self._layout_style
-                        + " layout algorithm)<br>"
+                        f"Hypergraph model visualization for the Model {model} (using the {self._layout_style} layout algorithm)<br>"
                     )
                 ocGraph.print_svg(
                     self.graphs[model],
@@ -841,9 +808,7 @@ class OCUtils:
             if self._HTMLFormat:
                 if header:
                     print(
-                        "Hypergraph model Gephi input for the Model "
-                        + model
-                        + "<br>"
+                        f"Hypergraph model Gephi input for the Model {model}<br>"
                     )
                 print(ocGraph.print_gephi(self.graphs[model]))
                 print("<hr>")
@@ -931,8 +896,7 @@ class OCUtils:
                 model, self._calc_expected_dv, self._fit_classifier_target
             )
 
-            print()
-            print()
+            print("\n")
 
     def occam2_settings(self):
         option = self._manager.getOption("action")
@@ -987,9 +951,9 @@ class OCUtils:
 
     def print_option(self, label, value):
         if self._HTMLFormat:
-            print("<tr><td>" + label + "</td><td>" + str(value) + "</td></tr>")
+            print(f"<tr><td>{label}</td><td>{value}</td></tr>")
         else:
-            print(label + "," + str(value))
+            print(f"{label},{value}")
 
     def print_options(self, r_type):
         if self._HTMLFormat:
@@ -1040,9 +1004,7 @@ class OCUtils:
 
         if self._generate_gephi or self._generate_graph:
             self.print_option(
-                "Hide "
-                + ("IV" if self.is_directed() else "IVI")
-                + " components in hypergraph",
+                f"Hide {'IV' if self.is_directed() else 'IVI'} components in hypergraph",
                 "Y" if self._hide_isolated else "N",
             )
 

--- a/py/py3/ocutils.py
+++ b/py/py3/ocutils.py
@@ -56,7 +56,9 @@ class OCUtils:
         self._percent_correct = 0
         self._ref_model = "default"
         self._report = self._manager.Report()
-        self._report.setSeparator(OCUtils.SPACE_SEP)  # align columns using spaces
+        self._report.setSeparator(
+            OCUtils.SPACE_SEP
+        )  # align columns using spaces
         self._report_file = ""
         self._report_sort_name = ""
         self._search_filter = "loopless"
@@ -105,7 +107,7 @@ class OCUtils:
     def set_report_separator(self, format_):
         occam3.setHTMLMode(format_ == OCUtils.HTML_FORMAT)
         self._report.setSeparator(format_)
-        self._HTMLFormat = (format_ == OCUtils.HTML_FORMAT)
+        self._HTMLFormat = format_ == OCUtils.HTML_FORMAT
 
     def set_fit_classifier_target(self, target):
         self._fit_classifier_target = target
@@ -237,11 +239,20 @@ class OCUtils:
     # on how search is sorting the models. We want to avoid any
     # extra expensive computations
     def compute_sort_statistic(self, model):
-        if self.sort_name == "h" or self.sort_name == "information" or self.sort_name == "unexplained" or self.sort_name == "alg_t":
+        if (
+            self.sort_name == "h"
+            or self.sort_name == "information"
+            or self.sort_name == "unexplained"
+            or self.sort_name == "alg_t"
+        ):
             self._manager.computeInformationsStatistics(model)
         elif self.sort_name == "df" or self.sort_name == "ddf":
             self._manager.computeDFStatistics(model)
-        elif self.sort_name == "bp_t" or self.sort_name == "bp_information" or self.sort_name == "bp_alpha":
+        elif (
+            self.sort_name == "bp_t"
+            or self.sort_name == "bp_information"
+            or self.sort_name == "bp_alpha"
+        ):
             self._manager.computeBPStatistics(model)
         elif self.sort_name == "pct_correct_data":
             self._manager.computePercentCorrect(model)
@@ -268,7 +279,9 @@ class OCUtils:
                 key = new_model.get(self.sort_name)
                 if self._search_sort_dir == "descending":
                     key = -key
-                heapq.heappush(new_models_heap, ([key, new_model.get("name")], new_model))  # appending the model name makes sort alphabet-consistent
+                heapq.heappush(
+                    new_models_heap, ([key, new_model.get("name")], new_model)
+                )  # appending the model name makes sort alphabet-consistent
                 add_count += 1
             else:
                 if self._incremental_alpha:
@@ -289,10 +302,12 @@ class OCUtils:
         while len(new_models_heap) > 0:
             # make sure that we're adding unique models to the list (mostly for state-based)
             key, candidate = heapq.heappop(new_models_heap)
-            if len(
-                    best_models) < self._search_width:  # or key[0] == last_key[0]:      # comparing keys allows us to select more than <width> models,
-                if True not in [n.isEquivalentTo(candidate) for n in
-                                best_models]:  # in the case of ties
+            if (
+                len(best_models) < self._search_width
+            ):  # or key[0] == last_key[0]:      # comparing keys allows us to select more than <width> models,
+                if True not in [
+                    n.isEquivalentTo(candidate) for n in best_models
+                ]:  # in the case of ties
                     best_models.append(candidate)
             else:
                 break
@@ -301,9 +316,10 @@ class OCUtils:
         self._total_kept = trunc_count + self._total_kept
         mem_used = self._manager.getMemUsage()
         if not self._hide_intermediate_output:
-            print('%d new models, %ld kept; %ld total models, %ld total kept; %ld kb memory used; ' % (
-                full_count, trunc_count, self._total_gen + 1, self._total_kept + 1,
-                mem_used / 1024), end=' ')
+            print(
+                f'{full_count} new models, {trunc_count} kept; {self._total_gen + 1} total models, {self._total_kept + 1} total kept; {mem_used / 1024} kb memory used; ',
+                end=' ',
+            )
         sys.stdout.flush()
         if clear_cache_flag:
             for item in new_models_heap:
@@ -364,7 +380,9 @@ class OCUtils:
                 if self._search_filter == "disjoint":
                     pass
                 elif self._search_filter == "chain":
-                    print('ERROR: Directed Down Chain Search not yet implemented.')
+                    print(
+                        'ERROR: Directed Down Chain Search not yet implemented.'
+                    )
                     raise sys.exit()
         else:
             if self.search_dir == "up":
@@ -373,7 +391,9 @@ class OCUtils:
                 if self._search_filter == "disjoint":
                     pass
                 elif self._search_filter == "chain":
-                    print('ERROR: Neutral Down Chain Search not yet implemented.')
+                    print(
+                        'ERROR: Neutral Down Chain Search not yet implemented.'
+                    )
                     raise sys.exit()
 
         if self._start_model == "":
@@ -383,10 +403,12 @@ class OCUtils:
         # set start model. For chain search, ignore any specific starting model
         # otherwise, if not set, set the start model based on search direction
         if (
-                self._search_filter == "chain" or self._start_model == "default") and self.search_dir == "down":
+            self._search_filter == "chain" or self._start_model == "default"
+        ) and self.search_dir == "down":
             self._start_model = "top"
         elif (
-                self._search_filter == "chain" or self._start_model == "default") and self.search_dir == "up":
+            self._search_filter == "chain" or self._start_model == "default"
+        ) and self.search_dir == "up":
             self._start_model = "bottom"
         if self._start_model == "top":
             start = self._manager.getTopRefModel()
@@ -436,11 +458,13 @@ class OCUtils:
                 print("Memory limit exceeded: stopping search")
                 break
             print(i, ':', end=' ')  # progress indicator
-            new_models = self.process_level(i, old_models,
-                                            i != self._search_levels)
+            new_models = self.process_level(
+                i, old_models, i != self._search_levels
+            )
             current_time = time.time()
-            print('%.1f seconds, %.1f total' % (
-                current_time - last_time, current_time - start_time))
+            print(
+                f'{current_time - last_time:.1f} seconds, {current_time - start_time:.1f} total'
+            )
             sys.stdout.flush()
             last_time = current_time
             for model in new_models:
@@ -472,9 +496,13 @@ class OCUtils:
             self._start_model = "default"
         if self.search_dir == "default":
             self.search_dir = "up"
-        if (self._search_filter == "chain" or self._start_model == "default") and self.search_dir == "down":
+        if (
+            self._search_filter == "chain" or self._start_model == "default"
+        ) and self.search_dir == "down":
             self._start_model = "top"
-        elif (self._search_filter == "chain" or self._start_model == "default") and self.search_dir == "up":
+        elif (
+            self._search_filter == "chain" or self._start_model == "default"
+        ) and self.search_dir == "up":
             self._start_model = "bottom"
         if self._start_model == "top":
             start = self._manager.getTopRefModel()
@@ -517,11 +545,13 @@ class OCUtils:
                 print("Memory limit exceeded: stopping search")
                 break
             print(i, ':', end=' ')  # progress indicator
-            new_models = self.process_level(i, old_models,
-                                            i != self._search_levels)
+            new_models = self.process_level(
+                i, old_models, i != self._search_levels
+            )
             current_time = time.time()
-            print('%.1f seconds, %.1f total' % (
-                current_time - last_time, current_time - start_time))
+            print(
+                f'{current_time - last_time:.1f} seconds, {current_time - start_time:.1f} total'
+            )
             last_time = current_time
             for model in new_models:
                 # Make sure all statistics are calculated. This won't do anything if we did it already.
@@ -593,9 +623,12 @@ class OCUtils:
 
     def split_model(self, model_name):
         comps = model_name.split(":")
-        model = [[s] if (
-            s == "IV" if self.is_directed() else s == "IVI") else self.split_caps(
-            s) for s in comps]
+        model = [
+            [s]
+            if (s == "IV" if self.is_directed() else s == "IVI")
+            else self.split_caps(s)
+            for s in comps
+        ]
         return model
 
     def check_model_name(self, model_name):
@@ -631,35 +664,57 @@ class OCUtils:
             if not varset.issubset(modset):
                 if self._HTMLFormat:
                     print("<br>")
-                print("\nERROR: Not all declared variables are present in the model, '" + model_name + "'.")
+                print(
+                    "\nERROR: Not all declared variables are present in the model, '"
+                    + model_name
+                    + "'."
+                )
                 if self._HTMLFormat:
                     print("<br>")
                 if saw_maybe_wrong_iv:
-                    print("\n_did you mean '" + (
-                        "IV" if is_directed else "IVI") + "' instead of '" + (
-                              "IVI" if is_directed else "IV") + "'?")
+                    print(
+                        "\n_did you mean '"
+                        + ("IV" if is_directed else "IVI")
+                        + "' instead of '"
+                        + ("IVI" if is_directed else "IV")
+                        + "'?"
+                    )
                 else:
-                    print("\n Did you forget the " + (
-                        "IV" if is_directed else "IVI") + " component?")
+                    print(
+                        "\n Did you forget the "
+                        + ("IV" if is_directed else "IVI")
+                        + " component?"
+                    )
                 if self._HTMLFormat:
                     print("<br>")
                 print("\n Not in model: ")
-                print(", ".join(
-                    ["'" + i + "'" for i in varset.difference(modset)]))
+                print(
+                    ", ".join(
+                        ["'" + i + "'" for i in varset.difference(modset)]
+                    )
+                )
                 sys.exit(1)
 
         # all variables in model are in varlist
         if not modset.issubset(varset):
             if self._HTMLFormat:
                 print("<br>")
-            print("\nERROR: Not all variables in the model '" + model_name + "' are declared in the variable list.")
+            print(
+                "\nERROR: Not all variables in the model '"
+                + model_name
+                + "' are declared in the variable list."
+            )
             if self._HTMLFormat:
                 print("<br>")
             diffset = modset.difference(varset)
             if saw_maybe_wrong_iv or diffset == {"I", "V"}:
-                print("\n_did you mean '" + (
-                    "IV" if is_directed else "IVI") + "' instead of '" + (
-                          "IVI" if is_directed else "IV") + "'?")
+                print(
+                    "\n_did you mean '"
+                    + ("IV" if is_directed else "IVI")
+                    + "' instead of '"
+                    + ("IVI" if is_directed else "IV")
+                    + "'?"
+                )
             else:
                 print("\n Not declared: ")
                 print(", ".join(["'" + i + "'" for i in diffset]))
@@ -673,16 +728,23 @@ class OCUtils:
                 if not (rel == ["IVI"] or rel == ["IV"]) and dv not in rel:
                     if self._HTMLFormat:
                         print("<br>")
-                    print("\nERROR: In the model '" + model_name + "', model component '" + "".join(
-                        rel) + "' is missing the DV, '" + dv + "'.")
+                    print(
+                        "\nERROR: In the model '"
+                        + model_name
+                        + "', model component '"
+                        + "".join(rel)
+                        + "' is missing the DV, '"
+                        + dv
+                        + "'."
+                    )
                     sys.exit(1)
 
     def print_graph(self, model_name, only):
         if only and not self._generate_gephi:
             self._generate_graph = True
         if (self._generate_graph or self._generate_gephi) and (
-                self._hide_isolated and (
-                model_name == "IVI" or model_name == "IV")):
+            self._hide_isolated and (model_name == "IVI" or model_name == "IV")
+        ):
             msg = "Note: no "
             if self._generate_graph:
                 msg = msg + "hypergraph image "
@@ -693,7 +755,10 @@ class OCUtils:
 
             msg = msg + "was generated, since the model contains only "
             msg = msg + model_name
-            msg = msg + " components, which were requested to be hidden in the graph."
+            msg = (
+                msg
+                + " components, which were requested to be hidden in the graph."
+            )
 
             if self._HTMLFormat:
                 print("<br>")
@@ -730,13 +795,18 @@ class OCUtils:
             if self._default_fit_model != "":
                 try:
                     default_model = self._manager.makeModel(
-                        self._default_fit_model, 1)
+                        self._default_fit_model, 1
+                    )
                 except Exception:
-                    print("\nERROR: Unable to create model " + self._default_fit_model)
+                    print(
+                        "\nERROR: Unable to create model "
+                        + self._default_fit_model
+                    )
                     sys.exit(0)
                 self._report.setDefaultFitModel(default_model)
-            self._report.printConditional_DV(model, self._calc_expected_dv,
-                                             self._fit_classifier_target)
+            self._report.printConditional_DV(
+                model, self._calc_expected_dv, self._fit_classifier_target
+            )
 
             self.print_graph(model_name, only_gfx)
 
@@ -746,10 +816,21 @@ class OCUtils:
             self.generate_graph(model)
             if self._HTMLFormat:
                 if header:
-                    print("Hypergraph model visualization for the Model " + model + " (using the " + self._layout_style + " layout algorithm)<br>")
-                ocGraph.print_svg(self.graphs[model], self._layout_style,
-                                  self._graph_width, self._graph_height,
-                                  self._graph_font_size, self._graph_node_size)
+                    print(
+                        "Hypergraph model visualization for the Model "
+                        + model
+                        + " (using the "
+                        + self._layout_style
+                        + " layout algorithm)<br>"
+                    )
+                ocGraph.print_svg(
+                    self.graphs[model],
+                    self._layout_style,
+                    self._graph_width,
+                    self._graph_height,
+                    self._graph_font_size,
+                    self._graph_node_size,
+                )
                 print("<hr>")
 
     def maybe_print_graph_gephi(self, model, header):
@@ -759,7 +840,11 @@ class OCUtils:
 
             if self._HTMLFormat:
                 if header:
-                    print("Hypergraph model Gephi input for the Model " + model + "<br>")
+                    print(
+                        "Hypergraph model Gephi input for the Model "
+                        + model
+                        + "<br>"
+                    )
                 print(ocGraph.print_gephi(self.graphs[model]))
                 print("<hr>")
 
@@ -769,21 +854,36 @@ class OCUtils:
         hide_dv = self._graph_hideDV
         full_var_names = self._full_var_names
         dv_name = ""
-        all_higher_order = (self._layout_style == "bipartite")
+        all_higher_order = self._layout_style == "bipartite"
         if self.is_directed():
             dv_name = self._report.dvName()
 
         if model in self.graphs:
             pass
         else:
-            self.graphs[model] = ocGraph.generate(model, varlist, hide_iv,
-                                                  hide_dv, dv_name,
-                                                  full_var_names,
-                                                  all_higher_order)
+            self.graphs[model] = ocGraph.generate(
+                model,
+                varlist,
+                hide_iv,
+                hide_dv,
+                dv_name,
+                full_var_names,
+                all_higher_order,
+            )
 
-    def set_gfx(self, use_gfx, layout=None, gephi=False, hide_iv=True,
-                hide_dv=True, full_var_names=False, width=640, height=480,
-                font_size=12, node_size=24):
+    def set_gfx(
+        self,
+        use_gfx,
+        layout=None,
+        gephi=False,
+        hide_iv=True,
+        hide_dv=True,
+        full_var_names=False,
+        width=640,
+        height=480,
+        font_size=12,
+        node_size=24,
+    ):
         self._generate_graph = use_gfx
         self._generate_gephi = gephi
         self._layout_style = layout
@@ -802,8 +902,9 @@ class OCUtils:
         self._report.addModel(model)
         self._manager.printFitReport(model)
         self._manager.makeFitTable(model)
-        self._report.printResiduals(model, self._skip_trained_model_table,
-                                    self._skip_ivi_tables)
+        self._report.printResiduals(
+            model, self._skip_trained_model_table, self._skip_ivi_tables
+        )
 
     def do_sb_fit(self, print_options):
         # self._manager.setValuesAreFunctions(self._values_are_functions)
@@ -817,13 +918,18 @@ class OCUtils:
             if self._default_fit_model != "":
                 try:
                     default_model = self._manager.makeSbModel(
-                        self._default_fit_model, 1)
+                        self._default_fit_model, 1
+                    )
                 except Exception:
-                    print("\nERROR: Unable to create model " + self._default_fit_model)
+                    print(
+                        "\nERROR: Unable to create model "
+                        + self._default_fit_model
+                    )
                     sys.exit(0)
                 self._report.setDefaultFitModel(default_model)
-            self._report.printConditional_DV(model, self._calc_expected_dv,
-                                             self._fit_classifier_target)
+            self._report.printConditional_DV(
+                model, self._calc_expected_dv, self._fit_classifier_target
+            )
 
             print()
             print()
@@ -894,7 +1000,8 @@ class OCUtils:
         if self._fit_classifier_target != "":
             self.print_option(
                 "Default ('negative') state for confusion matrices",
-                self._fit_classifier_target)
+                self._fit_classifier_target,
+            )
         if r_type == 1:
             self.print_option("Starting model", self._start_model)
             self.print_option("Search direction", self.search_dir)
@@ -908,24 +1015,36 @@ class OCUtils:
             self.print_option("Report preference", self._sort_dir)
 
         if r_type == 0:
-            self.print_option("Generate hypergraph images",
-                              "Y" if self._generate_graph else "N")
-            self.print_option("Generate Gephi files",
-                              "Y" if self._generate_gephi else "N")
+            self.print_option(
+                "Generate hypergraph images",
+                "Y" if self._generate_graph else "N",
+            )
+            self.print_option(
+                "Generate Gephi files", "Y" if self._generate_gephi else "N"
+            )
 
         if self._generate_graph:
-            self.print_option("Hypergraph layout style",
-                              str(self._layout_style))
+            self.print_option(
+                "Hypergraph layout style", str(self._layout_style)
+            )
             self.print_option("Hypergraph image width", str(self._graph_width))
-            self.print_option("Hypergraph image height",
-                              str(self._graph_height))
-            self.print_option("Hypergraph font size", str(self._graph_font_size))
-            self.print_option("Hypergraph node size", str(self._graph_node_size))
+            self.print_option(
+                "Hypergraph image height", str(self._graph_height)
+            )
+            self.print_option(
+                "Hypergraph font size", str(self._graph_font_size)
+            )
+            self.print_option(
+                "Hypergraph node size", str(self._graph_node_size)
+            )
 
         if self._generate_gephi or self._generate_graph:
-            self.print_option("Hide " + (
-                "IV" if self.is_directed() else "IVI") + " components in hypergraph",
-                              "Y" if self._hide_isolated else "N")
+            self.print_option(
+                "Hide "
+                + ("IV" if self.is_directed() else "IVI")
+                + " components in hypergraph",
+                "Y" if self._hide_isolated else "N",
+            )
 
         if self._HTMLFormat:
             print("</table>")
@@ -937,12 +1056,16 @@ class OCUtils:
         # Initialize a manager and the starting model
         self.set_ref_model(self._ref_model)
         self._manager.setSearchDirection(
-            1 if (self.search_dir == "down") else 0)
+            1 if (self.search_dir == "down") else 0
+        )
         self._manager.setSearchType(self.search_type())
 
         # Set up the starting model
-        start = self._manager.getTopRefModel() if (
-                self.search_dir == "down") else self._manager.getBottomRefModel()
+        start = (
+            self._manager.getTopRefModel()
+            if (self.search_dir == "down")
+            else self._manager.getBottomRefModel()
+        )
         start.level = 0
         self._manager.computeL2Statistics(start)
         self._manager.computeDependentStatistics(start)
@@ -955,8 +1078,9 @@ class OCUtils:
         old_models = [start]
         for i in range(1, self._search_levels + 1):
             sys.stdout.write('.')
-            new_models = self.process_level(i, old_models,
-                                            i != self._search_levels)
+            new_models = self.process_level(
+                i, old_models, i != self._search_levels
+            )
             for model in new_models:
                 self._manager.computeL2Statistics(model)
                 self._manager.computeDependentStatistics(model)
@@ -975,6 +1099,6 @@ class OCUtils:
 
     def compute_binary_statistic(self, compare_order, key):
         file_ref, model_ref, file_comp, model_comp = compare_order
-        return self._manager.computeBinaryStatistic(file_ref, model_ref,
-                                                    file_comp, model_comp,
-                                                    key)
+        return self._manager.computeBinaryStatistic(
+            file_ref, model_ref, file_comp, model_comp, key
+        )

--- a/py/py3/sbfit.py
+++ b/py/py3/sbfit.py
@@ -13,8 +13,8 @@ import time
 from ocutils import OCUtils
 
 if len(sys.argv) < 3:
-    print('Incorrect parameters.')
-    print(f'Usage: {sys.argv[0]} datafile model')
+    print(f'Incorrect parameters.\nUsage: {sys.argv[0]} datafile model')
+    print(f'')
     sys.exit()
 
 

--- a/py/py3/sbfit.py
+++ b/py/py3/sbfit.py
@@ -6,6 +6,7 @@
 # distribution of this software for license terms.
 
 import sys
+
 # sys.path.append("/www")
 import time
 
@@ -13,7 +14,7 @@ from ocutils import OCUtils
 
 if len(sys.argv) < 3:
     print('Incorrect parameters.')
-    print('Usage: %s datafile model' % sys.argv[0])
+    print(f'Usage: {sys.argv[0]} datafile model')
     sys.exit()
 
 
@@ -31,5 +32,5 @@ t2 = time.time()
 oc.do_action(0)
 t3 = time.time()
 
-print("start:  %8f" % (t2 - t1))
-print("fit: %8f" % (t3 - t2))
+print(f"start:  {(t2 - t1):8f}")
+print(f"fit: {(t3 - t2):8f}")

--- a/py/py3/sbsearch.py
+++ b/py/py3/sbsearch.py
@@ -7,6 +7,7 @@
 
 import resource
 import sys
+
 # sys.path.append("/www")
 import time
 
@@ -18,7 +19,9 @@ resource.setrlimit(resource.RLIMIT_CORE, [360000, 360000])
 # The width, levels and filter are determined here, to be used by the rest of the script below.
 if len(sys.argv) < 2:
     print('No data file specified.')
-    print('Usage: %s datafile [width levels] ["all"|"loopless"|"disjoint"|"chain"]' % sys.argv[0])
+    print(
+        f'Usage: {sys.argv[0]} datafile [width levels] ["all"|"loopless"|"disjoint"|"chain"]'
+    )
     sys.exit()
 
 if len(sys.argv) >= 4:
@@ -96,12 +99,14 @@ util.set_report_sort_name("information")
 # util.set_no_ipf(1)
 # For ref=bottom, use something like this:
 # util.set_report_variables("Level$i, h, ddf, lr, alpha, information, cond_pct_dh, aic, bic, incr_alpha, prog_id")
-util.set_report_variables("level$I, h, ddf, lr, alpha, information, aic, bic, incr_alpha, prog_id, pct_correct_data")
+util.set_report_variables(
+    "level$I, h, ddf, lr, alpha, information, aic, bic, incr_alpha, prog_id, pct_correct_data"
+)
 
 # Perform the search or fit. Pass 1 as argument to print options, 0 not to.
 t2 = time.time()
 util.do_action(1)
 t3 = time.time()
 
-print("start:  %8f" % (t2 - t1))
-print("search: %8f" % (t3 - t2))
+print(f"start:  {(t2 - t1):8f}")
+print(f"search: {(t3 - t2):8f}")

--- a/py/py3/setup.py
+++ b/py/py3/setup.py
@@ -1,10 +1,11 @@
 from distutils.core import setup
 
-setup(name='occampy',
-      version='1.0',
-      description='OCCAM Reconstructability Analysis Tools',
-      author='Tim Coutinho, Huy Yang, Lily Cox, Gabriel Miller, Sebastian Reynolds, Carla Rubio-Lamas, Evghenii Siretanu, Ian McBride',
-      author_email='NA',
-      url='https://github.com/tim-coutinho/occam',
-      packages=[],
+setup(
+    name='occampy',
+    version='1.0',
+    description='OCCAM Reconstructability Analysis Tools',
+    author='Tim Coutinho, Huy Yang, Lily Cox, Gabriel Miller, Sebastian Reynolds, Carla Rubio-Lamas, Evghenii Siretanu, Ian McBride',
+    author_email='NA',
+    url='https://github.com/tim-coutinho/occam',
+    packages=[],
 )

--- a/py/py3/weboccam.py
+++ b/py/py3/weboccam.py
@@ -71,17 +71,14 @@ csvname = ""
 def print_headers(form_fields, text_format):
     if text_format:
         global csvname
-        origcsvname = get_data_file_name(form_fields, true) + ".csv"
-        csvname = get_unique_filename("data/" + origcsvname)
+        origcsvname = f"{get_data_file_name(form_fields, true)}.csv"
+        csvname = get_unique_filename(f"data/{origcsvname}")
         if use_gfx(form_fields):
             # REDIRECT OUTPUT FOR NOW (it will be printed in output_zipfile())
             print("Content-type: application/octet-stream")
             print(
-                "Content-disposition: attachment; filename="
-                + get_data_file_name(form_fields, true)
-                + ".zip"
+                f"Content-disposition: attachment; filename={get_data_file_name(form_fields, true)}.zip\n"
             )
-            print("")
             sys.stdout.flush()
 
             global stdout_save
@@ -92,11 +89,11 @@ def print_headers(form_fields, text_format):
 
         else:
             print("Content-type: application/octet-stream")
-            print("Content-disposition: attachment; filename=" + origcsvname)
+            print(f"Content-disposition: attachment; filename={origcsvname}")
 
     else:
         print("Content-type: text/html")
-    print("")
+    print()
 
 
 def print_top(template, text_format):
@@ -129,13 +126,7 @@ def attempt_parse_int(string, default, msg, verbose):
         if verbose:
             print(
                 (
-                    "WARNING: expected "
-                    + msg
-                    + " to be an integer value, but got: \""
-                    + string
-                    + "\"; using the default value, "
-                    + str(default)
-                    + "\n"
+                    f'WARNING: expected {msg} to be an integer value, but got: "{string}"; using the default value, "{default}"\n'
                 )
             )
             if not text_format:
@@ -187,7 +178,7 @@ def output_to_zip(oc):
     global csvname
 
     # Make an empty zip file
-    zipname = "data/" + get_data_file_name(form_fields, true) + ".zip"
+    zipname = f"data/{get_data_file_name(form_fields, true)}.zip"
     z = zipfile.ZipFile(zipname, "w")
 
     sys.stdout.flush()
@@ -196,8 +187,8 @@ def output_to_zip(oc):
         modelname = modelname.replace(":", "_")
 
         if "gfx" in form_fields:
-            filename = modelname + ".pdf"
-            print("Writing graph to " + filename)
+            filename = f"{modelname}.pdf"
+            print(f"Writing graph to {filename}")
             graph_file = ocGraph.print_pdf(
                 modelname,
                 graph,
@@ -211,18 +202,18 @@ def output_to_zip(oc):
             sys.stdout.flush()
 
         if "gephi" in form_fields:
-            nodename = modelname + ".nodes_table.csv"
-            print("Writing Gephi Node table file to " + nodename)
+            nodename = f"{modelname}.nodes_table.csv"
+            print(f"Writing Gephi Node table file to {nodename}")
             nodetext = ocGraph.gephi_nodes(graph)
-            nodefile = get_unique_filename("data/" + nodename)
+            nodefile = get_unique_filename(f"data/{nodename}")
             with open(nodefile, "w") as nf:
                 nf.write(nodetext)
             z.write(nodefile, nodename)
 
-            edgename = modelname + ".edges_table.csv"
-            print("Writing Gephi Edges table file to " + edgename)
+            edgename = f"{modelname}.edges_table.csv"
+            print(f"Writing Gephi Edges table file to {edgename}")
             edgetext = ocGraph.gephi_edges(graph)
-            edgefile = get_unique_filename("data/" + edgename)
+            edgefile = get_unique_filename(f"data/{edgename}")
             with open(edgefile, "w") as ef:
                 ef.write(edgetext)
             z.write(edgefile, edgename)
@@ -232,7 +223,7 @@ def output_to_zip(oc):
     sys.stdout = os.fdopen(stdout_save, 'w')
 
     # Write the CSV to the ZIP
-    z.write(csvname, get_data_file_name(form_fields, true) + ".csv")
+    z.write(csvname, f"{get_data_file_name(form_fields, true)}.csv")
     z.close()
 
     # print out the zipfile
@@ -277,16 +268,16 @@ def print_form(form_fields):
             template.set_template("data.template.html")
             template.out(form_fields)
 
-        template.set_template(action + ".template.html")
+        template.set_template(f"{action}.template.html")
         template.out(form_fields)
         template.set_template("output.template.html")
         template.out(form_fields)
 
-        template.set_template(action + ".footer.html")
+        template.set_template(f"{action}.footer.html")
         template.out(form_fields)
 
     elif action in ["compare", "log", "fitbatch"]:
-        template.set_template(action + "form.html")
+        template.set_template(f"{action}form.html")
         template.out(form_fields)
 
     if action == "jobcontrol":
@@ -390,9 +381,7 @@ def prepare_cached_data(form_fields):
         drn = os.path.join(datadir, data_refr_name)
         if not os.path.isfile(drn):
             print(
-                "ERROR: Data file corresponding to Cached Data Name, '"
-                + data_refr_name
-                + "', does not exist"
+                f"ERROR: Data file corresponding to Cached Data Name, '{data_refr_name}', does not exist"
             )
             sys.exit(1)
         data = open(drn).read()
@@ -406,9 +395,7 @@ def prepare_cached_data(form_fields):
         print(trn)
         if not os.path.isfile(trn):
             print(
-                "ERROR: Test file corresponding to Cached Test Name, '"
-                + test_refr_name
-                + "', does not exist"
+                f"ERROR: Test file corresponding to Cached Test Name, '{test_refr_name}', does not exist"
             )
             sys.exit(1)
         test = open(trn).read()
@@ -419,10 +406,9 @@ def prepare_cached_data(form_fields):
     data_refr_tag = os.path.split(data_refr_name)[1]
     test_refr_tag = os.path.split(test_refr_name)[1]
 
-    final_data_file = decls + "\n" + data + "\n" + test
+    final_data_file = f"{decls}\n{data}\n{test}"
 
-    final_data_file_name = decls_file_name + "." + data_refr_tag
-    final_data_file_name = final_data_file_name + ".txt"
+    final_data_file_name = f"{decls_file_name}.{data_refr_tag}.txt"
     final_data_file_name = os.path.join(datadir, final_data_file_name)
 
     with open(final_data_file_name, "w") as f:
@@ -864,7 +850,7 @@ def action_batch_compare(form_fields):
 
     # Validate the datafile as a zip file containing the proper named pairs.
     if not zipfile.is_zipfile(fn):
-        print("ERROR: " + fn + " is not a zipped archive.")
+        print(f"ERROR: {fn} is not a zipped archive.")
         sys.exit()
 
     def make_pairs(zip_data):
@@ -887,14 +873,10 @@ def action_batch_compare(form_fields):
             if not (a[:-1] == b[:-1]):
                 print("ERROR: Expected matching paired data, but got<br></br>")
                 print(
-                    "&emsp;&emsp;'"
-                    + sorted_data[2 * ix].filename
-                    + "',<br></br>"
+                    f"&emsp;&emsp;'{sorted_data[2 * ix].filename}',<br></br>"
                 )
                 print(
-                    "&emsp;&emsp;'"
-                    + sorted_data[2 * ix + 1].filename
-                    + "'.<br></br>"
+                    f"&emsp;&emsp;'{sorted_data[2 * ix + 1].filename}'.<br></br>"
                 )
                 print(
                     "For each pair in the zipfile, the 2 filenames must be the same"
@@ -945,10 +927,10 @@ def action_batch_compare(form_fields):
         ]
         for i in report_1 + report_2:
             if i in candidate:
-                headers.append(i[:-1] + "(A))")
-                headers.append(i[:-1] + "(B))")
+                headers.append(f"{i[:-1]}(A))")
+                headers.append(f"{i[:-1]}(B))")
             if i in report_fields_2:
-                headers.append(i + "(model(A) : model(B))")
+                headers.append(f"{i}(model(A) : model(B))")
         return headers
 
     global text_format, print_options
@@ -1036,8 +1018,8 @@ def action_batch_compare(form_fields):
     def run_analysis(pair_name, file_a, file_b):
         model_a = compute_best_model(file_a)
         model_b = compute_best_model(file_b)
-        model_a["filename"] = pair_name + "A.txt"
-        model_b["filename"] = pair_name + "B.txt"
+        model_a["filename"] = f"{pair_name}A.txt"
+        model_b["filename"] = f"{pair_name}B.txt"
 
         best, stats_1, stats_2 = compute_model_stats(model_a, model_b)
         return (
@@ -1056,7 +1038,7 @@ def action_batch_compare(form_fields):
     def pp_options():
         for (k, v) in list(search.items()):
             if v != '':
-                print(tab_row(tab_col(k + ": ") + tab_col(v)))
+                print(tab_row(tab_col(f"{k}: ") + tab_col(v)))
 
     def pp_column_list():
         print(
@@ -1119,8 +1101,7 @@ def action_batch_compare(form_fields):
         results.append([l, s1, s2])
         os.remove(file_a)
         os.remove(file_b)
-    print()
-    print("Searches completed. ")
+    print("\nSearches completed. ")
 
     if not text_format:
         print(table_start)
@@ -1319,7 +1300,7 @@ def get_timestamped_filename(file_name):
     prefix, suffix = os.path.splitext(filename)
     prefix = '_'.join(prefix.split())
     timestamp = datetime.datetime.now().strftime("%Y_%m_%d-%H_%M_%S")
-    filename = os.path.join(dirname, prefix + "_" + timestamp + suffix)
+    filename = os.path.join(dirname, f"{prefix}_{timestamp}{suffix}")
     return filename
 
 
@@ -1405,7 +1386,7 @@ def print_batch_log(email):
 def start_normal(form_fields):
     # if any subject line was supplied, print it
     if "email_subject" in form_fields and form_fields["email_subject"]:
-        print("Subject line:," + form_fields["email_subject"])
+        print(f"Subject line:,{form_fields['email_subject']}")
 
     try:
         if form_fields["action"] == "fit":
@@ -1437,7 +1418,7 @@ def start_normal(form_fields):
         else:
             if not text_format:
                 print("<br><hr>")
-            print("FATAL ERROR: " + str(e))
+            print(f"FATAL ERROR: {str(e)}")
             if not text_format:
                 print("<br>")
             print("This error was not expected by the programmer. ")
@@ -1499,7 +1480,7 @@ if "batch_output" in form_fields and form_fields["batch_output"]:
 
 sys.stdout.flush()
 
-# print sys.executable + "<br>" + platform.python_version() + "<br>"
+# print(f"{sys.executable}<br>{platform.python_version()}<br>"
 
 # If this is not an output page, or reporting a batch job, then print the header form
 if "data" not in form_fields and "email" not in form_fields:

--- a/py/py3/weboccam.py
+++ b/py/py3/weboccam.py
@@ -7,14 +7,15 @@
 
 
 import cgi
+import cgitb
+import datetime
+import distanceFunctions
+import os
+import pickle
 import sys
 import time
-import pickle
-import zipfile
-import datetime
-import cgitb
 import traceback
-import distanceFunctions
+import zipfile
 
 from ocutils import OCUtils
 from OpagCGI import OpagCGI
@@ -47,12 +48,21 @@ def get_data_file_name(form_fields, trim=false, key='datafilename'):
     * form_fields:   the form data from the user
     * trim:         trim the extension from the filename.
     """
-    return '_'.join(apply_if(trim, lambda d: os.path.splitext(d)[0],
-                             os.path.split(form_fields[key])[1]).split())
+    return '_'.join(
+        apply_if(
+            trim,
+            lambda d: os.path.splitext(d)[0],
+            os.path.split(form_fields[key])[1],
+        ).split()
+    )
 
 
 def use_gfx(form_fields):
-    return "only_gfx" in form_fields or "gfx" in form_fields or "gephi" in form_fields
+    return (
+        "only_gfx" in form_fields
+        or "gfx" in form_fields
+        or "gephi" in form_fields
+    )
 
 
 csvname = ""
@@ -66,8 +76,11 @@ def print_headers(form_fields, text_format):
         if use_gfx(form_fields):
             # REDIRECT OUTPUT FOR NOW (it will be printed in output_zipfile())
             print("Content-type: application/octet-stream")
-            print("Content-disposition: attachment; filename=" + get_data_file_name(
-                form_fields, true) + ".zip")
+            print(
+                "Content-disposition: attachment; filename="
+                + get_data_file_name(form_fields, true)
+                + ".zip"
+            )
             print("")
             sys.stdout.flush()
 
@@ -100,9 +113,9 @@ def print_time(text_format):
     elapsed_t = now - startt
     if elapsed_t > 0:
         if text_format:
-            print("Run time: %f seconds\n" % elapsed_t)
+            print(f"Run time: {elapsed_t} seconds\n")
         else:
-            print("<br>Run time: %f seconds</br>" % elapsed_t)
+            print(f"<br>Run time: {elapsed_t} seconds</br>")
 
 
 def attempt_parse_int(string, default, msg, verbose):
@@ -114,8 +127,17 @@ def attempt_parse_int(string, default, msg, verbose):
 
     except ValueError:
         if verbose:
-            print(("WARNING: expected " + msg + " to be an integer value, but got: \"" + string + "\"; using the default value, " + str(
-                   default) + "\n"))
+            print(
+                (
+                    "WARNING: expected "
+                    + msg
+                    + " to be an integer value, but got: \""
+                    + string
+                    + "\"; using the default value, "
+                    + str(default)
+                    + "\n"
+                )
+            )
             if not text_format:
                 print("<br>")
 
@@ -123,27 +145,39 @@ def attempt_parse_int(string, default, msg, verbose):
 
 
 def graph_width():
-    return attempt_parse_int(form_fields.get("graph_width", ""), 640,
-                             "hypergraph image width",
-                             "gfx" in form_fields)
+    return attempt_parse_int(
+        form_fields.get("graph_width", ""),
+        640,
+        "hypergraph image width",
+        "gfx" in form_fields,
+    )
 
 
 def graph_height():
-    return attempt_parse_int(form_fields.get("graph_height", ""), 480,
-                             "hypergraph image height",
-                             "gfx" in form_fields)
+    return attempt_parse_int(
+        form_fields.get("graph_height", ""),
+        480,
+        "hypergraph image height",
+        "gfx" in form_fields,
+    )
 
 
 def graph_font_size():
-    return attempt_parse_int(form_fields.get("graph_font_size", ""), 12,
-                             "hypergraph font size",
-                             "gfx" in form_fields)
+    return attempt_parse_int(
+        form_fields.get("graph_font_size", ""),
+        12,
+        "hypergraph font size",
+        "gfx" in form_fields,
+    )
 
 
 def graph_node_size():
-    return attempt_parse_int(form_fields.get("graph_node_size", ""), 24,
-                             "hypergraph node size",
-                             "gfx" in form_fields)
+    return attempt_parse_int(
+        form_fields.get("graph_node_size", ""),
+        24,
+        "hypergraph node size",
+        "gfx" in form_fields,
+    )
 
 
 # Take the captured standard output,
@@ -164,11 +198,15 @@ def output_to_zip(oc):
         if "gfx" in form_fields:
             filename = modelname + ".pdf"
             print("Writing graph to " + filename)
-            graph_file = ocGraph.print_pdf(modelname, graph,
-                                           form_fields["layout"],
-                                           graph_width(), graph_height(),
-                                           graph_font_size(),
-                                           graph_node_size())
+            graph_file = ocGraph.print_pdf(
+                modelname,
+                graph,
+                form_fields["layout"],
+                graph_width(),
+                graph_height(),
+                graph_font_size(),
+                graph_node_size(),
+            )
             z.write(graph_file, filename)
             sys.stdout.flush()
 
@@ -260,7 +298,7 @@ def print_form(form_fields):
 #
 def action_form(form, error_text):
     if error_text:
-        print("<H2>Error: %s</H2><BR>" % error_text)
+        print(f"<H2>Error: {error_text}</H2><BR>")
     print_form(form)
 
 
@@ -272,7 +310,8 @@ def get_data_file_alloc(form_fields, key='datafilename'):
         print("ERROR: No data file specified.")
         sys.exit()
     datafile = get_unique_filename(
-        os.path.join(datadir, get_data_file_name(form_fields)))
+        os.path.join(datadir, get_data_file_name(form_fields))
+    )
     try:
         outf = open(datafile, "w", 0o660)
         data = form_fields["data"]
@@ -282,7 +321,7 @@ def get_data_file_alloc(form_fields, key='datafilename'):
         if get_data_file_name(form_fields) == "":
             print("ERROR: No data file specified.")
         else:
-            print("ERROR: Problems reading data file %s." % datafile)
+            print(f"ERROR: Problems reading data file {datafile}.")
         sys.exit()
     return datafile
 
@@ -297,7 +336,7 @@ def get_data_file_alloc_by_name(fn, data):
         outf.write(data)
         outf.close()
     except Exception:
-        print("ERROR: Problems reading data file %s." % datafile)
+        print(f"ERROR: Problems reading data file {datafile}.")
         sys.exit()
     return datafile
 
@@ -327,13 +366,18 @@ def prepare_cached_data(form_fields):
 
     # Check that exactly 1 of datafile, refr were chosen
     if (data_file_name == "" and data_refr_name == "") or (
-            data_file_name != "" and data_refr_name != ""):
-        print("NOTE: Exactly 1 of 'Data File' and 'Cached Data Name' must be filled out.")
+        data_file_name != "" and data_refr_name != ""
+    ):
+        print(
+            "NOTE: Exactly 1 of 'Data File' and 'Cached Data Name' must be filled out."
+        )
         sys.exit(1)
 
     # Check that at most 1 of testfile, testrefr were chosen
     if test_file_name != "" and test_refr_name != "":
-        print("ERROR: At most 1 of 'Test File' and 'Cached Test Name' must be filled out.")
+        print(
+            "ERROR: At most 1 of 'Test File' and 'Cached Test Name' must be filled out."
+        )
         sys.exit(1)
 
     def unpack_to_string(fn, data):
@@ -345,7 +389,11 @@ def prepare_cached_data(form_fields):
     if data_file_name == "":  # search for the Cached Data Name and combine.
         drn = os.path.join(datadir, data_refr_name)
         if not os.path.isfile(drn):
-            print("ERROR: Data file corresponding to Cached Data Name, '" + data_refr_name + "', does not exist")
+            print(
+                "ERROR: Data file corresponding to Cached Data Name, '"
+                + data_refr_name
+                + "', does not exist"
+            )
             sys.exit(1)
         data = open(drn).read()
 
@@ -357,7 +405,11 @@ def prepare_cached_data(form_fields):
         trn = os.path.join(datadir, test_refr_name)
         print(trn)
         if not os.path.isfile(trn):
-            print("ERROR: Test file corresponding to Cached Test Name, '" + test_refr_name + "', does not exist")
+            print(
+                "ERROR: Test file corresponding to Cached Test Name, '"
+                + test_refr_name
+                + "', does not exist"
+            )
             sys.exit(1)
         test = open(trn).read()
 
@@ -412,17 +464,22 @@ def unzip_data_file(datafile):
         oldfile = datafile
         zipdata = zipfile.ZipFile(datafile)
         # ignore any directories, or files in them, such as those OSX likes to make
-        ilist = [item for item in zipdata.infolist() if
-                 item.filename.find("/") == -1]
+        ilist = [
+            item
+            for item in zipdata.infolist()
+            if item.filename.find("/") == -1
+        ]
         # make sure there is only one file left
         if len(ilist) != 1:
-            print("ERROR: Zip file can only contain one data file. (It appears to contain %d.)" % len(
-                ilist))
+            print(
+                f"ERROR: Zip file can only contain one data file. (It appears to contain {len(ilist)}.)"
+            )
             sys.exit()
         # try to extract the file
         try:
-            datafile = os.path.join(datadir, ilist[0].filename)
-            datafile = get_timestamped_filename(datafile)
+            datafile = get_timestamped_filename(
+                os.path.join(datadir, ilist[0].filename)
+            )
             outf = open(datafile, "w")
             outf.write(zipdata.read(ilist[0].filename))
             outf.close()
@@ -494,16 +551,18 @@ def maybe_skip_ivis(form_fields, oc):
 def handle_graph_options(oc, form_fields):
     if use_gfx(form_fields):
         lo = form_fields["layout"]
-        oc.set_gfx("gfx" in form_fields,
-                   layout=lo,
-                   gephi="gephi" in form_fields,
-                   hideIV="hide_isolated" in form_fields,
-                   hideDV="hideDV" in form_fields,
-                   full_var_names="full_var_names" in form_fields,
-                   width=graph_width(),
-                   height=graph_height(),
-                   font_size=graph_font_size(),
-                   node_size=graph_node_size())
+        oc.set_gfx(
+            "gfx" in form_fields,
+            layout=lo,
+            gephi="gephi" in form_fields,
+            hideIV="hide_isolated" in form_fields,
+            hideDV="hideDV" in form_fields,
+            full_var_names="full_var_names" in form_fields,
+            width=graph_width(),
+            height=graph_height(),
+            font_size=graph_font_size(),
+            node_size=graph_node_size(),
+        )
 
 
 def action_fit(form_fields):
@@ -534,7 +593,11 @@ def action_fit(form_fields):
     # if function_flag:
     # oc.set_values_are_functions(1)
 
-    target = form_fields["negativeDVfor_confusion"] if "negativeDVfor_confusion" in form_fields else ""
+    target = (
+        form_fields["negativeDVfor_confusion"]
+        if "negativeDVfor_confusion" in form_fields
+        else ""
+    )
 
     maybe_skip_residuals(form_fields, oc)
     maybe_skip_ivis(form_fields, oc)
@@ -592,7 +655,11 @@ def action_sb_fit(form_fields):
     maybe_skip_residuals(form_fields, oc)
     maybe_skip_ivis(form_fields, oc)
 
-    target = form_fields["negativeDVfor_confusion"] if "negativeDVfor_confusion" in form_fields else ""
+    target = (
+        form_fields["negativeDVfor_confusion"]
+        if "negativeDVfor_confusion" in form_fields
+        else ""
+    )
 
     only_gfx = "only_gfx" in form_fields
     process_sb_fit(fn, form_fields["model"], target, oc, only_gfx)
@@ -681,18 +748,27 @@ def action_search(form_fields):
     reportvars += ", ddf"
     if form_fields.get("show_dlr", ""):
         reportvars += ", lr"
-    if form_fields.get("show_alpha",
-                       "") or search_sort == "alpha" or report_sort == "alpha":
+    if (
+        form_fields.get("show_alpha", "")
+        or search_sort == "alpha"
+        or report_sort == "alpha"
+    ):
         reportvars += ", alpha"
     reportvars += ", information"
     if oc.is_directed():
         if form_fields.get("show_pct_dh", ""):
             reportvars += ", cond_pct_dh"
-    if form_fields.get("show_aic",
-                       "") or search_sort == "aic" or report_sort == "aic":
+    if (
+        form_fields.get("show_aic", "")
+        or search_sort == "aic"
+        or report_sort == "aic"
+    ):
         reportvars += ", aic"
-    if form_fields.get("show_bic",
-                       "") or search_sort == "bic" or report_sort == "bic":
+    if (
+        form_fields.get("show_bic", "")
+        or search_sort == "bic"
+        or report_sort == "bic"
+    ):
         reportvars += ", bic"
 
     if form_fields.get("show_incr_a", ""):
@@ -708,8 +784,12 @@ def action_search(form_fields):
         """
 
     if oc.is_directed():
-        if form_fields.get("show_pct", "") or form_fields.get("show_pct_cover",
-                                                              "") or search_sort == "pct_correct_data" or report_sort == "pct_correct_data":
+        if (
+            form_fields.get("show_pct", "")
+            or form_fields.get("show_pct_cover", "")
+            or search_sort == "pct_correct_data"
+            or report_sort == "pct_correct_data"
+        ):
             reportvars += ", pct_correct_data"
             if form_fields.get("show_pct_cover", ""):
                 reportvars += ", pct_coverage"
@@ -734,25 +814,49 @@ def action_batch_compare(form_fields):
     # Get data from the form
 
     # Get Occam search parameters
-    search_fields = ["type", "direction", "levels", "width", "sort by",
-                     "selection function"]
+    search_fields = [
+        "type",
+        "direction",
+        "levels",
+        "width",
+        "sort by",
+        "selection function",
+    ]
     search = {key: form_fields.get(key) for key in search_fields}
 
     # Get Occam report parameters
     report_1 = []
     report_2 = []
-    report_fields_1 = ["DF(data)", "H(data)", "dBIC(model)", "dAIC(model)",
-                       "DF(model)", "H(model)"]
-    report_fields_2 = ["Absolute dist", "Information dist",
-                       "Kullback-Leibler dist", "Euclidean dist",
-                       "Maximum dist", "Hellinger dist"]
+    report_fields_1 = [
+        "DF(data)",
+        "H(data)",
+        "dBIC(model)",
+        "dAIC(model)",
+        "DF(model)",
+        "H(model)",
+    ]
+    report_fields_2 = [
+        "Absolute dist",
+        "Information dist",
+        "Kullback-Leibler dist",
+        "Euclidean dist",
+        "Maximum dist",
+        "Hellinger dist",
+    ]
 
-    d = {"max(DF)": "DF(model)", "min(H)": "H(model)",
-         "min(dAIC)": "dAIC(model)", "min(dBIC)": "dBIC(model)"}
+    d = {
+        "max(DF)": "DF(model)",
+        "min(H)": "H(model)",
+        "min(dAIC)": "dAIC(model)",
+        "min(dBIC)": "dBIC(model)",
+    }
 
     for r, rf in [(report_1, report_fields_1), (report_2, report_fields_2)]:
         for key in sorted(rf):
-            if form_fields.get(key, "") == "yes" or d[search["selection function"]] == key:
+            if (
+                form_fields.get(key, "") == "yes"
+                or d[search["selection function"]] == key
+            ):
                 r.append(key)
 
     # Check if the datafile field has a file in it.
@@ -772,7 +876,9 @@ def action_batch_compare(form_fields):
             sys.exit()
 
         if len(sorted_data) % 2 != 0:
-            print("ERROR: Expected an even number of datafiles inside the zip archive.")
+            print(
+                "ERROR: Expected an even number of datafiles inside the zip archive."
+            )
             sys.exit()
         for ix in range(len(sorted_data) / 2):
             g = lambda i: os.path.splitext(sorted_data[i].filename)[0]
@@ -780,21 +886,33 @@ def action_batch_compare(form_fields):
             b = g(2 * ix + 1)
             if not (a[:-1] == b[:-1]):
                 print("ERROR: Expected matching paired data, but got<br></br>")
-                print("&emsp;&emsp;'" + sorted_data[
-                    2 * ix].filename + "',<br></br>")
-                print("&emsp;&emsp;'" + sorted_data[
-                    2 * ix + 1].filename + "'.<br></br>")
-                print("For each pair in the zipfile, the 2 filenames must be the same")
-                print("except for exactly 1 character immediately before the extension which differs<br></br>")
+                print(
+                    "&emsp;&emsp;'"
+                    + sorted_data[2 * ix].filename
+                    + "',<br></br>"
+                )
+                print(
+                    "&emsp;&emsp;'"
+                    + sorted_data[2 * ix + 1].filename
+                    + "'.<br></br>"
+                )
+                print(
+                    "For each pair in the zipfile, the 2 filenames must be the same"
+                )
+                print(
+                    "except for exactly 1 character immediately before the extension which differs<br></br>"
+                )
                 print("&emsp;&emsp;(e.g. 'fileA.txt', 'fileB.txt').")
                 sys.exit()
             pairs.append(
-                (a[:-1], sorted_data[2 * ix], sorted_data[2 * ix + 1]))
+                (a[:-1], sorted_data[2 * ix], sorted_data[2 * ix + 1])
+            )
         return pairs
 
     zip_data = zipfile.ZipFile(fn)
     pairs = make_pairs(
-        [i for i in zip_data.infolist() if i.filename.find("/") == -1])
+        [i for i in zip_data.infolist() if i.filename.find("/") == -1]
+    )
 
     # Define the analysis.
     # Steps:
@@ -817,8 +935,14 @@ def action_batch_compare(form_fields):
     # Figure out what statistics to include (and in what reporting order)
     def get_stat_headers():
         headers = []
-        candidate = ["H(data)", "H(model)", "DF(data)", "DF(model)",
-                     "dAIC(model)", "dBIC(model)"]
+        candidate = [
+            "H(data)",
+            "H(model)",
+            "DF(data)",
+            "DF(model)",
+            "dAIC(model)",
+            "dBIC(model)",
+        ]
         for i in report_1 + report_2:
             if i in candidate:
                 headers.append(i[:-1] + "(A))")
@@ -887,8 +1011,10 @@ def action_batch_compare(form_fields):
         return d, s
 
     def compute_binary_statistics(report_items, comp_order):
-        stats = {k: distanceFunctions.compute_distance_metric(k, comp_order)
-                 for k in report_items}
+        stats = {
+            k: distanceFunctions.compute_distance_metric(k, comp_order)
+            for k in report_items
+        }
         return stats
 
     def compute_model_stats(model_a, model_b):
@@ -914,8 +1040,11 @@ def action_batch_compare(form_fields):
         model_b["filename"] = pair_name + "B.txt"
 
         best, stats_1, stats_2 = compute_model_stats(model_a, model_b)
-        return [pair_name, model_a["name"], model_b["name"],
-                best], stats_1, stats_2
+        return (
+            [pair_name, model_a["name"], model_b["name"], best],
+            stats_1,
+            stats_2,
+        )
 
     # Print out the report
     # * Print out options if requested
@@ -930,28 +1059,35 @@ def action_batch_compare(form_fields):
                 print(tab_row(tab_col(k + ": ") + tab_col(v)))
 
     def pp_column_list():
-        print(tab_row(tab_col("columns in report: ") + tab_col(
-            ", ".join(report_1 + report_2))))
+        print(
+            tab_row(
+                tab_col("columns in report: ")
+                + tab_col(", ".join(report_1 + report_2))
+            )
+        )
 
     def pp_analysis(row):
         return "".join(map(tab_col, row))
 
     def pp_stats(stats_1, stats_2):
         s = ""
-        fmt = "%.6g"
         for (k, v) in sorted(stats_1.items()):
             for i in [0, 1]:
                 if k[:2] == "DF":
-                    s += tab_col("%.0f" % v[i])
+                    s += tab_col(f"{v[i]:.0f}")
                 else:
-                    s += tab_col(fmt % v[i])
+                    s += tab_col(f"{v[i]:.6g}")
         for (k, v) in sorted(stats_2.items()):
-            s += tab_col(fmt % v)
+            s += tab_col(f"{v:.6g}")
         return s
 
     def pp_header():
-        col_headers = ["pair name", "model(A)", "model(B)",
-                       search["selection function"]] + get_stat_headers()
+        col_headers = [
+            "pair name",
+            "model(A)",
+            "model(B)",
+            search["selection function"],
+        ] + get_stat_headers()
         return "".join(map(tab_head, col_headers))
 
     # Layout the document
@@ -960,8 +1096,12 @@ def action_batch_compare(form_fields):
         print('<div class="data">')
     if not text_format:
         print(table_start)
-    print(tab_row(
-        tab_head("Input archive: ") + tab_col(get_data_file_name(form_fields))))
+    print(
+        tab_row(
+            tab_head("Input archive: ")
+            + tab_col(get_data_file_name(form_fields))
+        )
+    )
     if print_options:
         print(tab_row(tab_head("Options:")))
         pp_options()
@@ -1078,18 +1218,27 @@ def action_sb_search(form_fields):
     reportvars += ", ddf"
     if form_fields.get("show_dlr", ""):
         reportvars += ", lr"
-    if form_fields.get("show_alpha",
-                       "") or search_sort == "alpha" or report_sort == "alpha":
+    if (
+        form_fields.get("show_alpha", "")
+        or search_sort == "alpha"
+        or report_sort == "alpha"
+    ):
         reportvars += ", alpha"
     reportvars += ", information"
     if oc.is_directed():
         if form_fields.get("show_pct_dh", ""):
             reportvars += ", cond_pct_dh"
-    if form_fields.get("show_aic",
-                       "") or search_sort == "aic" or report_sort == "aic":
+    if (
+        form_fields.get("show_aic", "")
+        or search_sort == "aic"
+        or report_sort == "aic"
+    ):
         reportvars += ", aic"
-    if form_fields.get("show_bic",
-                       "") or search_sort == "bic" or report_sort == "bic":
+    if (
+        form_fields.get("show_bic", "")
+        or search_sort == "bic"
+        or report_sort == "bic"
+    ):
         reportvars += ", bic"
 
     if form_fields.get("show_incr_a", ""):
@@ -1105,8 +1254,12 @@ def action_sb_search(form_fields):
         """
 
     if oc.is_directed():
-        if form_fields.get("show_pct", "") or form_fields.get("show_pct_cover",
-                                                              "") or search_sort == "pct_correct_data" or report_sort == "pct_correct_data":
+        if (
+            form_fields.get("show_pct", "")
+            or form_fields.get("show_pct_cover", "")
+            or search_sort == "pct_correct_data"
+            or report_sort == "pct_correct_data"
+        ):
             reportvars += ", pct_correct_data"
             if form_fields.get("show_pct_cover", ""):
                 reportvars += ", pct_coverage"
@@ -1180,8 +1333,9 @@ def start_batch(form_fields):
     if get_data_file_name(form_fields) == "":
         print("ERROR: No data file specified.")
         sys.exit()
-    ctlfilename = os.path.join(datadir,
-                               get_data_file_name(form_fields, true) + '.ctl')
+    ctlfilename = os.path.join(
+        datadir, get_data_file_name(form_fields, true) + '.ctl'
+    )
     ctlfilename = get_unique_filename(ctlfilename)
     csvname = get_data_file_name(form_fields, true) + '.csv'
     datafilename = get_data_file_name(form_fields)
@@ -1197,16 +1351,15 @@ def start_batch(form_fields):
 
     print("Process ID:", os.getpid(), "<p>")
 
-    cmd = 'nohup "%s" "%s" "%s" "%s" "%s" "%s" &' % (
-        appname, sys.argv[0], ctlfilename, toaddress, csvname,
-        email_subject.encode("hex"))
+    cmd = f'nohup {appname} {sys.argv[0]} {ctlfilename} {toaddress} {csvname} {email_subject.encode("hex")}'
     os.system(cmd)
 
-    print("<hr>Batch job started for data file '%s'.<br>Results will be sent to '%s'" % (
-        datafilename, toaddress))
+    print(
+        f"<hr>Batch job started for data file '{datafilename}'.<br>Results will be sent to '{toaddress}'"
+    )
 
     if len(email_subject) > 0:
-        print(" with email subject line including '%s'." % email_subject)
+        print(f" with email subject line including '{email_subject}'.")
 
 
 #
@@ -1246,7 +1399,7 @@ def print_batch_log(email):
         f.close()
         print(the_log)
     except Exception:
-        print("no log file found for %s<br>" % email)
+        print(f"no log file found for {email}<br>")
 
 
 def start_normal(form_fields):
@@ -1263,7 +1416,10 @@ def start_normal(form_fields):
             action_sb_fit(form_fields)
         elif form_fields["action"] == "fitbatch":
             action_fit_batch(form_fields)
-        elif form_fields["action"] == "search" or form_fields["action"] == "advanced":
+        elif (
+            form_fields["action"] == "search"
+            or form_fields["action"] == "advanced"
+        ):
             action_search(form_fields)
         elif form_fields["action"] == "log":
             action_show_log(form_fields)
@@ -1285,7 +1441,9 @@ def start_normal(form_fields):
             if not text_format:
                 print("<br>")
             print("This error was not expected by the programmer. ")
-            print("For help, please contact h.forrest.alexander@gmail.com, and include the output so far ")
+            print(
+                "For help, please contact h.forrest.alexander@gmail.com, and include the output so far "
+            )
             ex_type, ex, tb = sys.exc_info()
             traceback.print_tb(tb)
             print("(end error message).")
@@ -1335,7 +1493,9 @@ if "batch_output" in form_fields and form_fields["batch_output"]:
     r2 = form_fields.pop('gephi', None)
     t = (r1 is not None) or (r2 is not None)
     if t:
-        print("Note: Occam's email server interacts with graph output in a way that currently results in an error; graph functionality is temporarily disabled. The programmer is working on a fix...<br><hr>")
+        print(
+            "Note: Occam's email server interacts with graph output in a way that currently results in an error; graph functionality is temporarily disabled. The programmer is working on a fix...<br><hr>"
+        )
 
 sys.stdout.flush()
 


### PR DESCRIPTION
Black: https://github.com/ambv/black
Specifically ran black -S -l 79 --fast *
-S to keep quotes the way they are instead of switching all to double
quotes, -l 79 to keep lines at 79 characters to comply with PEP8, and
--fast in order for it to work on the python2 files. There should be no
logical changes, only formatting; I haven't tested it though.